### PR TITLE
Recover performance when extending vectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,19 @@ pub mod common {
     }
     impl<T> Push<T> for Vec<T> {
         #[inline(always)] fn push(&mut self, item: T) { self.push(item) }
+
+        #[inline(always)]
+        fn extend(&mut self, iter: impl IntoIterator<Item=T>) {
+            std::iter::Extend::extend(self, iter)
+        }
     }
     impl<'a, T: Clone> Push<&'a T> for Vec<T> {
         #[inline(always)] fn push(&mut self, item: &'a T) { self.push(item.clone()) }
+
+        #[inline(always)]
+        fn extend(&mut self, iter: impl IntoIterator<Item=&'a T>) {
+            std::iter::Extend::extend(self, iter.into_iter().cloned())
+        }
     }
     impl<'a, T: Clone> Push<&'a [T]> for Vec<T> {
         #[inline(always)] fn push(&mut self, item: &'a [T]) { self.clone_from_slice(item) }


### PR DESCRIPTION
Implement `Push::extend` for pushing single items into vectors. This recovers some performance compared to relying on the default implementation.

Before the change:
```
test u64_copy         ... bench:     718,027.89 ns/iter (+/- 128,055.21)
```

After the change:
```
test u64_copy         ... bench:     152,634.24 ns/iter (+/- 35,799.85)
```
