### PR TITLE
Dramatic reworking of trait structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "columnar"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Conversion from arrays of complex structs to simple structs of arrays"
 edition = "2021"
@@ -17,7 +17,7 @@ bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytemuck = "1.20"
-columnar_derive = { path = "columnar_derive", version = "0.1" }
+columnar_derive = { path = "columnar_derive", version = "0.2" }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -67,7 +67,7 @@ impl Op {
                 let mut result = Strings::default();
                 for a in aa.iter() {
                     use columnar::Push;
-                    result.push(format!("{:?}", a));
+                    result.push(&format!("{:?}", a));
                 }
                 Err(result)
             },

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,5 +1,5 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use columnar::{Columnar, Clear, bytes::{AsBytes, FromBytes}};
+use columnar::{Columnar, Container, Clear, AsBytes, FromBytes};
 
 fn bench_new(b: &mut Bencher) {
     b.iter(|| {
@@ -17,7 +17,7 @@ fn bench_push(b: &mut Bencher) {
         container.push(&log);
     }
     let mut words = vec![];
-    ::columnar::bytes::serialization::encode(&mut words, container.as_bytes());
+    ::columnar::bytes::serialization::encode(&mut words, container.borrow().as_bytes());
     b.bytes = 8 * words.len() as u64;
     b.iter(|| {
         container.clear();
@@ -36,11 +36,11 @@ fn bench_encode(b: &mut Bencher) {
         container.push(&log);
     }
     let mut words = vec![];
-    ::columnar::bytes::serialization::encode(&mut words, container.as_bytes());
+    ::columnar::bytes::serialization::encode(&mut words, container.borrow().as_bytes());
     b.bytes = 8 * words.len() as u64;
     b.iter(|| {
         words.clear();
-        ::columnar::bytes::serialization::encode(&mut words, container.as_bytes());
+        ::columnar::bytes::serialization::encode(&mut words, container.borrow().as_bytes());
         bencher::black_box(&words);
     });
 }
@@ -53,11 +53,11 @@ fn bench_decode(b: &mut Bencher) {
     for _ in 0..1024 {
         container.push(&log);
     }
-    ::columnar::bytes::serialization::encode(&mut words, container.as_bytes());
+    ::columnar::bytes::serialization::encode(&mut words, container.borrow().as_bytes());
     b.bytes = 8 * words.len() as u64;
     b.iter(|| {
         let mut slices = ::columnar::bytes::serialization::decode(&mut words);
-        let foo = <<Log as Columnar>::Container as AsBytes>::Borrowed::from_bytes(&mut slices);
+        let foo = <<Log as Columnar>::Container as Container<Log>>::Borrowed::from_bytes(&mut slices);
         bencher::black_box(foo);
     });
 }

--- a/columnar_derive/Cargo.toml
+++ b/columnar_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "columnar_derive"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Derive macros for columnar crate"
 edition = "2021"

--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -20,7 +20,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         syn::Data::Enum(data_enum) => {
             derive_enum(name, &ast.generics, data_enum, ast.vis)
         }
-        _ => unimplemented!(),
+        syn::Data::Union(_) => unimplemented!("Unions are unsupported by Columnar"),
     }
 }
 
@@ -59,7 +59,7 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
     // The container struct is a tuple of containers, named to correspond with fields.
     let container_struct = {
         quote! {
-            #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+            #[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
             #vis struct #c_ident < #(#container_types),* >{
                 #(pub #names : #container_types, )*
             }
@@ -253,14 +253,14 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
 
     let as_bytes = { 
 
-        let impl_gen = quote! { < #(#container_types),* > };
+        let impl_gen = quote! { <'a, #(#container_types),* > };
         let ty_gen = quote! { < #(#container_types),* > };
-        let where_clause = quote! { where #(#container_types: ::columnar::bytes::AsBytes),* };
+        let where_clause = quote! { where #(#container_types: ::columnar::AsBytes<'a>),* };
         
         quote! {
-            impl #impl_gen ::columnar::bytes::AsBytes for #c_ident #ty_gen #where_clause {
-                type Borrowed<'columnar> = #c_ident < #(<#container_types as ::columnar::bytes::AsBytes>::Borrowed<'columnar>,)*>;
-                fn as_bytes(&self) -> impl Iterator<Item=(u64, &[u8])> {
+            impl #impl_gen ::columnar::AsBytes<'a> for #c_ident #ty_gen #where_clause {
+                // type Borrowed<'columnar> = #c_ident < #(<#container_types as ::columnar::AsBytes>::Borrowed<'columnar>,)*>;
+                fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
                     let iter = None.into_iter();
                     #( let iter = iter.chain(self.#names.as_bytes()); )*
                     iter
@@ -273,12 +273,12 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
 
         let impl_gen = quote! { < 'columnar, #(#container_types),* > };
         let ty_gen = quote! { < #(#container_types),* > };
-        let where_clause = quote! { where #(#container_types: ::columnar::bytes::FromBytes<'columnar>),* };
+        let where_clause = quote! { where #(#container_types: ::columnar::FromBytes<'columnar>),* };
         
         quote! {
-            impl #impl_gen ::columnar::bytes::FromBytes<'columnar> for #c_ident #ty_gen #where_clause {
+            impl #impl_gen ::columnar::FromBytes<'columnar> for #c_ident #ty_gen #where_clause {
                 fn from_bytes(bytes: &mut impl Iterator<Item=&'columnar [u8]>) -> Self {
-                    #(let #names = ::columnar::bytes::FromBytes::from_bytes(bytes);)*
+                    #(let #names = ::columnar::FromBytes::from_bytes(bytes);)*
                     Self { #(#names,)* }
                 }
             }
@@ -296,10 +296,33 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
         else {
             quote! { where #(#types : ::columnar::Columnar,)* }
         };
+    
+        // Either use curly braces or parentheses to destructure the item.
+        let destructure_self = 
+        if named { quote! { let #name { #(#names),* } = self; } }
+        else     { quote! { let #name ( #(#names),* ) = self; } };
+        
 
         quote! {
             impl #impl_gen ::columnar::Columnar for #name #ty_gen #where_clause2 {
                 type Container = #c_ident < #(<#types as ::columnar::Columnar>::Container ),* >;
+            }
+
+            impl #impl_gen ::columnar::Reference for #name #ty_gen #where_clause2 {
+                type Ref<'a> = #r_ident < #(<#types as ::columnar::Reference>::Ref<'a>,)* > where #(#types: 'a,)*;
+                fn copy_from<'a>(&mut self, other: Self::Ref<'a>) {
+                    #destructure_self
+                    #( ::columnar::Reference::copy_from(#names, other.#names); )*
+                }
+            }
+
+            impl #impl_gen ::columnar::Container<#name #ty_gen> for #c_ident < #(<#types as ::columnar::Columnar>::Container ),* > #where_clause2 {
+                type Borrowed<'a> = #c_ident < #(<<#types as ::columnar::Columnar>::Container as ::columnar::Container<#types>>::Borrowed<'a> ),* > where #(#types: 'a,)*;
+                fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
+                    #c_ident {
+                        #( #names: self.#names.borrow(), )*
+                    }
+                }
             }
         }
     };
@@ -337,9 +360,9 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
 
     quote! {
 
-        #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-        #vis struct #c_ident {
-            count: u64,
+        #[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+        #vis struct #c_ident<CW = u64> {
+            count: CW,
         }
 
         impl ::columnar::Push<#name> for #c_ident {
@@ -354,14 +377,14 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             }
         }
 
-        impl ::columnar::Index for #c_ident {
+        impl<CW> ::columnar::Index for #c_ident<CW> {
             type Ref = #name;
             fn get(&self, index: usize) -> Self::Ref {
                 #name
             }
         }
 
-        impl<'columnar> ::columnar::Index for &'columnar #c_ident {
+        impl<'columnar, CW> ::columnar::Index for &'columnar #c_ident<CW> {
             type Ref = #name;
             fn get(&self, index: usize) -> Self::Ref {
                 #name
@@ -374,27 +397,40 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             }
         }
 
-        impl ::columnar::Len for #c_ident {
+        impl<CW: Copy+::columnar::common::index::CopyAs<u64>> ::columnar::Len for #c_ident<CW> {
             fn len(&self) -> usize {
-                self.count as usize
+                use columnar::common::index::CopyAs;
+                self.count.copy_as() as usize
             }
         }
 
-        impl ::columnar::bytes::AsBytes for #c_ident {
-            type Borrowed<'columnar> = #c_ident;
-            fn as_bytes(&self) -> impl Iterator<Item=(u64, &[u8])> {
-                std::iter::once((8, bytemuck::cast_slice(std::slice::from_ref(&self.count))))
+        impl<'a> ::columnar::AsBytes<'a> for #c_ident <&'a u64> {
+            // type Borrowed<'columnar> = #c_ident;
+            fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
+                std::iter::once((8, bytemuck::cast_slice(std::slice::from_ref(self.count))))
             }
         }
 
-        impl<'columnar> ::columnar::bytes::FromBytes<'columnar> for #c_ident {
+        impl<'columnar> ::columnar::FromBytes<'columnar> for #c_ident <&'columnar u64> {
             fn from_bytes(bytes: &mut impl Iterator<Item=&'columnar [u8]>) -> Self {
-                Self { count: bytemuck::try_cast_slice(bytes.next().unwrap()).unwrap()[0] }
+                Self { count: &bytemuck::try_cast_slice(bytes.next().unwrap()).unwrap()[0] }
             }
         }
 
         impl ::columnar::Columnar for #name {
             type Container = #c_ident;
+        }
+
+        impl ::columnar::Reference for #name {
+            type Ref<'a> = #name;
+            fn copy_from<'a>(&mut self, other: Self::Ref<'a>) { *self = other; }
+        }
+
+        impl ::columnar::Container<#name> for #c_ident {
+            type Borrowed<'a> = #c_ident < &'a u64 >;
+            fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
+                #c_ident { count: &self.count }
+            }
         }
 
     }.into()
@@ -440,7 +476,7 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
     
     let container_struct = {
         quote! {
-            #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+            #[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
             #[allow(non_snake_case)]
             #vis struct #c_ident < #(#container_types,)* CVar = Vec<u8>, COff = Vec<u64>, >{
                 #(pub #names : #container_types, )*
@@ -680,14 +716,13 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
 
     let as_bytes = { 
 
-        let impl_gen = quote! { < #(#container_types,)* CVar, COff> };
+        let impl_gen = quote! { < 'a, #(#container_types,)* CVar, COff> };
         let ty_gen = quote! { < #(#container_types,)* CVar, COff > };
-        let where_clause = quote! { where #(#container_types: ::columnar::bytes::AsBytes,)* CVar: ::columnar::bytes::AsBytes, COff: ::columnar::bytes::AsBytes };
+        let where_clause = quote! { where #(#container_types: ::columnar::AsBytes<'a>,)* CVar: ::columnar::AsBytes<'a>, COff: ::columnar::AsBytes<'a> };
         
         quote! {
-            impl #impl_gen ::columnar::bytes::AsBytes for #c_ident #ty_gen #where_clause {
-                type Borrowed<'columnar> = #c_ident < #(<#container_types as ::columnar::bytes::AsBytes>::Borrowed<'columnar>,)* <CVar as ::columnar::bytes::AsBytes>::Borrowed<'columnar>, <COff as ::columnar::bytes::AsBytes>::Borrowed<'columnar>>;
-                fn as_bytes(&self) -> impl Iterator<Item=(u64, &[u8])> {
+            impl #impl_gen ::columnar::AsBytes<'a> for #c_ident #ty_gen #where_clause {
+                fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
                     let iter = None.into_iter();
                     #( let iter = iter.chain(self.#names.as_bytes()); )*
                     let iter = iter.chain(self.variant.as_bytes());
@@ -702,15 +737,15 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
 
         let impl_gen = quote! { < 'columnar, #(#container_types,)* CVar, COff> };
         let ty_gen = quote! { < #(#container_types,)* CVar, COff > };
-        let where_clause = quote! { where #(#container_types: ::columnar::bytes::FromBytes<'columnar>,)* CVar: ::columnar::bytes::FromBytes<'columnar>, COff: ::columnar::bytes::FromBytes<'columnar> };
+        let where_clause = quote! { where #(#container_types: ::columnar::FromBytes<'columnar>,)* CVar: ::columnar::FromBytes<'columnar>, COff: ::columnar::FromBytes<'columnar> };
         
         quote! {
             #[allow(non_snake_case)]
-            impl #impl_gen ::columnar::bytes::FromBytes<'columnar> for #c_ident #ty_gen #where_clause {
+            impl #impl_gen ::columnar::FromBytes<'columnar> for #c_ident #ty_gen #where_clause {
                 fn from_bytes(bytes: &mut impl Iterator<Item=&'columnar [u8]>) -> Self {
-                    #(let #names = ::columnar::bytes::FromBytes::from_bytes(bytes);)*
-                    let variant = ::columnar::bytes::FromBytes::from_bytes(bytes);
-                    let offset = ::columnar::bytes::FromBytes::from_bytes(bytes);
+                    #(let #names = ::columnar::FromBytes::from_bytes(bytes);)*
+                    let variant = ::columnar::FromBytes::from_bytes(bytes);
+                    let offset = ::columnar::FromBytes::from_bytes(bytes);
                     Self { #(#names,)* variant, offset }
                 }
             }
@@ -725,17 +760,76 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
 
         let where_clause2 = if let Some(enum_where) = where_clause {
             let params = enum_where.predicates.iter(); 
-            quote! {  where #(#types : ::columnar::Columnar,)* #(#params),* }
+            quote! {  where #(#types : ::columnar::Columnar + Default,)* #(#params),* }
         }
         else {
-            quote! { where #(#types : ::columnar::Columnar,)* }
+            quote! { where #(#types : ::columnar::Columnar + Default,)* }
         };
 
+
+        let variant_types = &variants.iter().map(|(_, types)| quote! { (#(#types),*) }).collect::<Vec<_>>();
+
         let container_types = &variants.iter().map(|(_, types)| quote! { <(#(#types),*) as ::columnar::Columnar>::Container }).collect::<Vec<_>>();
+
+        let reference_args = variants.iter().map(|(_, types)| quote! { <(#(#types),*) as ::columnar::Reference>::Ref<'a> });
+
+        // For each variant of `other`, the matching and non-matching variant cases.
+        let copy_from = variants.iter().enumerate().map(|(index, (variant, types))| {
+
+            if data_enum.variants[index].fields == syn::Fields::Unit {
+                quote! { 
+                    (#name::#variant, #r_ident::#variant(_)) => { }
+                    (_, #r_ident::#variant(_)) => { *self = #name::#variant; }
+                }
+            }
+            else {
+                let temp_names1 = &types.iter().enumerate().map(|(index, _)| {
+                    let new_name = format!("s{}", index);
+                    syn::Ident::new(&new_name, variant.span())
+                }).collect::<Vec<_>>();
+                let temp_names2 = &types.iter().enumerate().map(|(index, _)| {
+                    let new_name = format!("t{}", index);
+                    syn::Ident::new(&new_name, variant.span())
+                }).collect::<Vec<_>>();
+
+                quote! {
+                    (#name::#variant( #( #temp_names1 ),* ), #r_ident::#variant( ( #( #temp_names2 ),* ) )) => {
+                        #( ::columnar::Reference::copy_from(#temp_names1, #temp_names2); )*
+                    }
+                    (_, #r_ident::#variant( ( #(#temp_names2),* ) )) => {
+                        #( 
+                            let mut #temp_names1 = Default::default(); 
+                            ::columnar::Reference::copy_from(&mut #temp_names1, #temp_names2);
+                        )*
+                        *self = #name::#variant( #( #temp_names1, )*);
+                    }
+                }
+            }
+        }).collect::<Vec<_>>();
 
         quote! {
             impl #impl_gen ::columnar::Columnar for #name #ty_gen #where_clause2 {
                 type Container = #c_ident < #(#container_types),* >;
+            }
+
+            impl #impl_gen ::columnar::Reference for #name #ty_gen #where_clause2 {
+                type Ref<'a> = #r_ident < #(#reference_args,)* > where Self: 'a, #(#variant_types: 'a,)*;
+                fn copy_from<'a>(&mut self, other: Self::Ref<'a>) {
+                    match (&mut *self, other) {
+                        #( #copy_from )*
+                    }
+                }
+            }
+
+            impl #impl_gen ::columnar::Container<#name #ty_gen> for #c_ident < #(#container_types),* > #where_clause2 {
+                type Borrowed<'a> = #c_ident < #( < #container_types as ::columnar::Container<#variant_types> >::Borrowed<'a>, )* &'a [u8], &'a [u64] > where #(#variant_types: 'a,)*;
+                fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
+                    #c_ident {
+                        #(#names: self.#names.borrow(),)*
+                        variant: self.variant.borrow(),
+                        offset: self.offset.borrow(),
+                    }
+                }
             }
         }
     };
@@ -782,7 +876,7 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
     assert!(names.len() <= 256, "Too many variants for enum");
 
     quote! {
-        #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+        #[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
         #vis struct #c_ident <CVar = Vec<u8>> {
             pub variant: CVar,
         }
@@ -835,21 +929,37 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             }
         }
 
-        impl<CVar: ::columnar::bytes::AsBytes> ::columnar::bytes::AsBytes for #c_ident <CVar> {
-            type Borrowed<'columnar> = #c_ident < <CVar as ::columnar::bytes::AsBytes>::Borrowed<'columnar> >;
-            fn as_bytes(&self) -> impl Iterator<Item=(u64, &[u8])> {
+        impl<'a, CVar: ::columnar::AsBytes<'a>> ::columnar::AsBytes<'a> for #c_ident <CVar> {
+            // type Borrowed<'columnar> = #c_ident < <CVar as ::columnar::AsBytes>::Borrowed<'columnar> >;
+            fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
                 self.variant.as_bytes()
             }
         }
 
-        impl<'columnar, CVar: ::columnar::bytes::FromBytes<'columnar>> ::columnar::bytes::FromBytes<'columnar> for #c_ident <CVar> {
+        impl<'columnar, CVar: ::columnar::FromBytes<'columnar>> ::columnar::FromBytes<'columnar> for #c_ident <CVar> {
             fn from_bytes(bytes: &mut impl Iterator<Item=&'columnar [u8]>) -> Self {
-                Self { variant: ::columnar::bytes::FromBytes::from_bytes(bytes) }
+                Self { variant: ::columnar::FromBytes::from_bytes(bytes) }
             }
         }
 
         impl ::columnar::Columnar for #name {
             type Container = #c_ident;
+        }
+
+        impl ::columnar::Reference for #name {
+            type Ref<'a> = #name;
+            fn copy_from<'a>(&mut self, other: Self::Ref<'a>) {
+                *self = other;
+            }
+        }
+
+        impl<CV: ::columnar::Container<u8>> ::columnar::Container<#name> for #c_ident <CV> {
+            type Borrowed<'a> = #c_ident < CV::Borrowed<'a> > where CV: 'a;
+            fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
+                #c_ident {
+                    variant: self.variant.borrow()
+                }
+            }
         }
     }.into()
 }


### PR DESCRIPTION
This PR dramatically reworks the core `Columnar` trait, to be based around `Reference` and `Container` traits. The main things they do are introduce associated types in a controlled manner.
```rust
pub trait Reference {
    type Ref<'a> where Self: 'a;
}

pub trait Container<C: Reference + ?Sized> {
    type Borrowed<'a>: Copy + AsBytes<'a> + FromBytes<'a> + Len + Index<Ref = C::Ref<'a>> where Self: 'a, C: 'a;
    fn borrow<'a>(&'a self) -> Self::Borrowed<'a>;
}
```
The intent is for columnar types `C` to also implement `Reference`, supplying an opinion about the shape that columnar references should have. For example, a `(A, Vec<B>)` type might indicate `(&'a A, &'a [B])` as its `Ref<'a>` type. The container associated with `(A, Vec<B>)`, for example `(Vec<A>, Vecs<Vec<B>>)` would also need to announce a corresponding borrowed form, potentially `(&'a [A], Vecs<&'a [B], &'a [u64]>)`. The borrowed forms would need to provide indexed access to the `Ref<'a>` type. Generally, container are accessed by borrowing them and then applying the traits implemented by the borrowed type.

This all seems to build and work locally, but it has not been stress tested against e.g. timely or differential. It is meant to be helpful for them, though, in that the `Ref<'a>` types bind together the various containers and provide more clarity around the types that you'll get back when you access the containers. At the same time, changing anything has the potential to unveil new limitations when we try and use it.