### PR TITLE
Support additional source types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ homepage = "http://github.com/frankmcsherry/columnar"
 repository = "https://github.com/frankmcsherry/columnar.git"
 license = "MIT"
 
+[workspace]
+members = ["columnar_derive"]
+
 [dependencies]
 rmp-serde = "1.3.0"
 bincode = "1.3.3"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The crate provides containers for types built out of product (`struct`), sum (`e
 The containers represent a sequence of the input types, but are backed by only a small number of Rust allocations (vectors or slices) even though each instance of the type may have many more allocations.
 Each of the container allocations contains only primitive types, and are easily converted to and from (correctly aligned) binary slices `&[u8]`.
 
-The containers supports efficient random access for reads, and limited forms of random access for writes.
+The containers support efficient random access for reads, and limited forms of random access for writes.
 
 ## An example
 


### PR DESCRIPTION
Adds support for
* Box<[T]> as a vector type
* Rc<[T]> as a vector type
* [T; N] as an approximated vector type. This is inefficient as it stores
  the offset, too, which we could recompute based on `N`.

Removes the `Default` requirement for `Option<T>`.

Fixes an ambiguous call to `borrow` in derived implementations.

Detects unsupported struct-like enum variants.

Declares `columnar_derive` as a workspace member.

Spelling fixes!

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
