### PR TITLE
Derive PartialEq and Eq for reference types

### DIFF
--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -121,6 +121,44 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
 
     };
 
+    let eq = {
+
+        let reference_types = &names.iter().enumerate().map(|(index, name)| {
+            let new_name = format!("R{}", index);
+            syn::Ident::new(&new_name, name.span())
+        }).collect::<Vec<_>>();
+
+        let impl_gen = quote! { < #(#reference_types),* > };
+
+        let where_clause = quote! { where #(#reference_types: Eq),* };
+
+        quote! {
+            impl #impl_gen Eq for #r_ident < #(#reference_types),* >  #where_clause { }
+        }
+
+    };
+
+    let partial_eq_self = {
+
+        let reference_types = &names.iter().enumerate().map(|(index, name)| {
+            let new_name = format!("R{}", index);
+            syn::Ident::new(&new_name, name.span())
+        }).collect::<Vec<_>>();
+
+        let impl_gen = quote! { < #(#reference_types),* > };
+
+        let where_clause = quote! { where #(#reference_types: PartialEq),* };
+
+        quote! {
+            impl #impl_gen PartialEq for #r_ident < #(#reference_types),* >  #where_clause {
+                fn eq(&self, other: &Self) -> bool {
+                    #(self.#names == other.#names) &&*
+                }
+            }
+        }
+
+    };
+
     let push_own = { 
         let (_impl_gen, ty_gen, _where_clause) = generics.split_for_impl();
         let push = names.iter().map(|name| { quote! { self.#name.push(#name); } });
@@ -346,6 +384,9 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
         #reference_struct
 
         #partial_eq
+        #partial_eq_self
+
+        #eq
 
         #push_own
         #push_ref


### PR DESCRIPTION
Derive PartialEq and Eq for reference types. This should be less contentious than deriving PartialOrd/Ord.

Ideally, this should be configurable using a custom derive annotation for the reference types.