### PR TITLE
Add ability to specify attributes on reference types

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,20 @@ mod test {
     #[derive(Columnar, Debug)]
     struct Test5;
 
+    // Test derived implementations for the reference type.
+    #[derive(Columnar, Debug)]
+    #[columnar(derive(Ord, PartialOrd, PartialEq, Eq))]
+    struct Test6 {
+        bar: i16,
+    }
+
+    #[test]
+    fn should_be_ord_eq() {
+        fn is_ord_eq<T: Ord + PartialOrd + PartialEq + Eq>() {}
+        is_ord_eq::<Test6Reference<i16>>();
+        is_ord_eq::<Test6Reference<&i16>>();
+    }
+
     #[test]
     fn round_trip() {
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,11 +224,13 @@ mod test {
 
     // Tests derived implementations for a struct with unnamed fields.
     #[derive(Columnar, Debug)]
+    #[columnar(derive(Ord, PartialOrd, PartialEq, Eq))]
     struct Test2<T: Copy> (Vec<T>, i16) where T: Clone;
 
     // Tests derived implementations for an enum with valuable variants,
     // but including unit variants.
     #[derive(Columnar, Debug)]
+    #[columnar(derive(Ord, PartialOrd, PartialEq, Eq))]
     pub enum Test3<T> {
         Foo(Vec<T>, u8),
         Bar(i16),
@@ -258,6 +260,8 @@ mod test {
         fn is_ord_eq<T: Ord + PartialOrd + PartialEq + Eq>() {}
         is_ord_eq::<Test6Reference<i16>>();
         is_ord_eq::<Test6Reference<&i16>>();
+
+        is_ord_eq::<Test3Reference<u8, u8, u8>>();
     }
 
     #[test]


### PR DESCRIPTION
Allows the user to do things like this:

```rust
#[derive(Columnar, Debug)]
#[columnar(derive(Ord, PartialOrd, PartialEq, Eq))]
struct MyStruct {
    bar: i16,
}
```

This will add `#[derive(...)]` to the `Reference` type's definition.

