### PR TITLE
Tidy up alignment, errors, and benchmarking

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -45,6 +45,14 @@ fn _bench_copy<T: Columnar+Eq>(bencher: &mut Bencher, record: T) where T::Contai
     // prepare encoded data for bencher.bytes
     let mut arena: T::Container = Default::default();
 
+    // get sizing information for throughput reports.
+    for _ in 0 .. 1024 {
+        arena.push(&record);
+    }
+    use columnar::{AsBytes, Container};
+    bencher.bytes = 8 * arena.borrow().length_in_words() as u64;
+    arena.clear();
+
     bencher.iter(|| {
         arena.clear();
         for _ in 0 .. 1024 {


### PR DESCRIPTION
A collection of updates, but notably:
1. A stack allocated `[u8; 8]` that was meant to be a `u64` was made a `u64` first in order to ensure alignment.
2. Many `unwrap()` calls became `expect()` calls and document their reasoning.
3. The return of `into_iter()` was made `impl Iterator` to allow overriding.