### PR TITLE
Revert a change to into_iter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub mod common {
                     slice: self,
                 }
             }
-            fn into_iter(self) -> impl Iterator<Item=Self::Ref> where Self: Sized + Len {
+            fn into_iter(self) -> IterOwn<Self> where Self: Sized {
                 IterOwn {
                     index: 0,
                     slice: self,


### PR DESCRIPTION
Make the return type of `into_iter` a concrete type instead of an impl trait. The impl trait doesn't play nicely with Timely's container trait.
