### PR TITLE
Support pushing iterators and formatters

### DIFF
--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -55,7 +55,7 @@ impl Op {
             Op::Len => {
                 let aa = &dataz[dataz.len()-1].as_ref().err().unwrap();
                 let mut result = Vec::with_capacity(aa.len());
-                for a in aa.into_iter() {
+                for a in aa.into_index_iter() {
                     result.push(a.len() as i32);
                 }
                 Ok(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ pub mod common {
             /// Converts `&self` into an iterator.
             ///
             /// This has an awkward name to avoid collision with `iter()`, which may also be implemented.
+            #[inline(always)]
             fn index_iter(&self) -> IterOwn<&Self> {
                 IterOwn {
                     index: 0,
@@ -199,6 +200,7 @@ pub mod common {
             /// Converts `self` into an iterator.
             ///
             /// This has an awkward name to avoid collision with `into_iter()`, which may also be implemented.
+            #[inline(always)]
             fn into_index_iter(self) -> IterOwn<Self> where Self: Sized {
                 IterOwn {
                     index: 0,
@@ -435,7 +437,7 @@ pub mod common {
         type Item = S::Ref;
         type IntoIter = IterOwn<Slice<S>>;
         fn into_iter(self) -> Self::IntoIter {
-            IterOwn { index: 0, slice: self }
+            self.into_index_iter()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,13 +187,19 @@ pub mod common {
                 if self.is_empty() { None }
                 else { Some(self.get(self.len()-1)) }
             }
-            fn iter(&self) -> IterOwn<&Self> {
+            /// Converts `&self` into an iterator.
+            ///
+            /// This has an awkward name to avoid collision with `iter()`, which may also be implemented.
+            fn index_iter(&self) -> IterOwn<&Self> {
                 IterOwn {
                     index: 0,
                     slice: self,
                 }
             }
-            fn into_iter(self) -> IterOwn<Self> where Self: Sized {
+            /// Converts `self` into an iterator.
+            ///
+            /// This has an awkward name to avoid collision with `into_iter()`, which may also be implemented.
+            fn into_index_iter(self) -> IterOwn<Self> where Self: Sized {
                 IterOwn {
                     index: 0,
                     slice: self,
@@ -422,6 +428,14 @@ pub mod common {
         #[inline(always)] fn get_mut(&mut self, index: usize) -> Self::IndexMut<'_> {
             assert!(index < self.upper - self.lower);
             self.slice.get_mut(self.lower + index)
+        }
+    }
+
+    impl<S: Index + Len> IntoIterator for Slice<S> {
+        type Item = S::Ref;
+        type IntoIter = IterOwn<Slice<S>>;
+        fn into_iter(self) -> Self::IntoIter {
+            IterOwn { index: 0, slice: self }
         }
     }
 
@@ -1109,6 +1123,20 @@ pub mod string {
             self.bounds.push(self.values.len() as u64);
         }
     }
+    impl<'a, BC: Push<u64>> Push<std::fmt::Arguments<'a>> for Strings<BC> {
+        fn push(&mut self, item: std::fmt::Arguments<'a>) {
+            use std::io::Write;
+            self.values.write_fmt(item).expect("write_fmt failed");
+            self.bounds.push(self.values.len() as u64);
+        }
+    }
+    impl<'a, 'b, BC: Push<u64>> Push<&'b std::fmt::Arguments<'a>> for Strings<BC> {
+        fn push(&mut self, item: &'b std::fmt::Arguments<'a>) {
+            use std::io::Write;
+            self.values.write_fmt(*item).expect("write_fmt failed");
+            self.bounds.push(self.values.len() as u64);
+        }
+    }
     impl<BC: Clear, VC: Clear> Clear for Strings<BC, VC> {
         fn clear(&mut self) {
             self.bounds.clear();
@@ -1246,28 +1274,13 @@ pub mod vector {
         }
     }
 
-    impl<TC: Push<TC2::Ref> + Len, TC2: Index> Push<Slice<TC2>> for Vecs<TC> {
-        fn push(&mut self, item: Slice<TC2>) {
+    impl<I: IntoIterator, TC: Push<I::Item> + Len> Push<I> for Vecs<TC> {
+        fn push(&mut self, item: I) {
             self.values.extend(item.into_iter());
             self.bounds.push(self.values.len() as u64);
         }
     }
-    impl<'a, T, TC: Push<&'a T> + Len> Push<&'a Vec<T>> for Vecs<TC> {
-        fn push(&mut self, item: &'a Vec<T>) {
-            self.push(&item[..]);
-        }
-    }
-    impl<'a, T, TC: Push<&'a T> + Len, const N: usize> Push<&'a [T; N]> for Vecs<TC> {
-        fn push(&mut self, item: &'a [T; N]) {
-            self.push(&item[..]);
-        }
-    }
-    impl<'a, T, TC: Push<&'a T> + Len> Push<&'a [T]> for Vecs<TC> {
-        fn push(&mut self, item: &'a [T]) {
-            self.values.extend(item.iter());
-            self.bounds.push(self.values.len() as u64);
-        }
-    }
+
     impl<TC: Clear> Clear for Vecs<TC> {
         fn clear(&mut self) {
             self.bounds.clear();
@@ -1930,7 +1943,7 @@ pub mod sums {
                 // Type annotation is important to avoid some inference overflow.
                 let store: Options<Vec<i32>> = Columnar::into_columns((0..100).map(Some));
                 assert_eq!(store.len(), 100);
-                assert!((&store).iter().zip(0..100).all(|(a, b)| a == Some(&b)));
+                assert!((&store).index_iter().zip(0..100).all(|(a, b)| a == Some(&b)));
                 assert_eq!(store.heap_size(), (408, 544));
             }
 
@@ -1939,7 +1952,7 @@ pub mod sums {
                 let store = Columnar::into_columns((0..100).map(|_x| None::<i32>));
                 assert_eq!(store.len(), 100);
                 let foo = &store;
-                assert!(foo.iter().zip(0..100).all(|(a, _b)| a == None));
+                assert!(foo.index_iter().zip(0..100).all(|(a, _b)| a == None));
                 assert_eq!(store.heap_size(), (8, 32));
             }
 
@@ -1948,7 +1961,7 @@ pub mod sums {
                 // Type annotation is important to avoid some inference overflow.
                 let store: Options<Vec<i32>>  = Columnar::into_columns((0..100).map(|x| if x % 2 == 0 { Some(x) } else { None }));
                 assert_eq!(store.len(), 100);
-                assert!((&store).iter().zip(0..100).all(|(a, b)| a == if b % 2 == 0 { Some(&b) } else { None }));
+                assert!((&store).index_iter().zip(0..100).all(|(a, b)| a == if b % 2 == 0 { Some(&b) } else { None }));
                 assert_eq!(store.heap_size(), (208, 288));
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     // Iterated column values should match the original `roster`.
     use columnar::Index;
-    for (col, row) in columns.into_iter().zip(roster) {
+    for (col, row) in columns.into_index_iter().zip(roster) {
         match (col, row) {
             (GroupReference::Solo(p0), Group::Solo(p1)) => {
                 assert_eq!(p0.0, p1.0);
@@ -45,8 +45,8 @@ fn main() {
     use columnar::Push;
     for index in 0 .. 1024 {
         columns.push(&Group::Team(vec![
-            (format!("Brain{}", index), index),
-            (format!("Brawn{}", index), index),
+            (format_args!("Brain{}", index), index),
+            (format_args!("Brawn{}", index), index),
         ]));
     }
 
@@ -274,7 +274,7 @@ mod test {
             Test1 { foo: vec![5, 6, 7], bar: 8 },
         ];
         let test1c = columnar::Columnar::as_columns(test1s.iter());
-        for (a, b) in test1s.into_iter().zip((&test1c).into_iter()) {
+        for (a, b) in test1s.into_iter().zip((&test1c).into_index_iter()) {
             assert_eq!(a.foo.len(), b.foo.len());
             assert_eq!(a.bar, *b.bar);
         }
@@ -287,7 +287,7 @@ mod test {
         
         println!("{:?}", test3c);
 
-        let iterc = (&test3c).into_iter();
+        let iterc = (&test3c).into_index_iter();
 
         for (a, b) in test3s.into_iter().zip(iterc) {
             match (a, &b) {
@@ -301,6 +301,19 @@ mod test {
                 _ => { panic!("Variant mismatch"); }
             }
         }
+
+    }
+
+    #[test]
+    fn iterators_formatters() {
+
+        use columnar::Push;
+
+        let mut columns = <((), Vec<usize>) as Columnar>::Container::default();
+        columns.push(((), 0 .. 10));
+
+        let mut columns = <((), String) as Columnar>::Container::default();
+        columns.push(((), format_args!("{:?}", 10)));
 
     }
 }


### PR DESCRIPTION
This PR introduces support for pushing iterators (things that implement `IntoIterator`) into `Vecs` and for pushing `std::fmt::Arguments` into `Strings`. This is meant to allow folks to introduce data without necessarily performing allocating constructions to get the data in the right shape. For example, one can both
```rust
        let mut columns = <((), Vec<usize>) as Columnar>::Container::default();
        columns.push(((), 0 .. 10));

        let mut columns = <((), String) as Columnar>::Container::default();
        columns.push(((), format_args!("{:?}", 10)));
```
which would normally require creating an actual vector and string, respectively.

There is fall-out! In particular, this makes the `Index::{iter, into_iter}` names much more clash-y, and so the PR changes them to `index_iter()` and `into_index_iter()` respectively. That may be horrible, and is certainly breaking. So, no rush to merge this, but some food for thought on how to get data in to columnar containers without as many allocations.