### PR TITLE
Support for `smallvec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = ["columnar_derive"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+smallvec = { version = "1.13.2", features = ["serde", "const_generics"] }
 bytemuck = "1.20"
 columnar_derive = { path = "columnar_derive", version = "0.2" }
 


### PR DESCRIPTION
The `smallvec` crate is pretty useful, and gets used in timely (and ideally differential) when one needs a `Vec` but doesn't want to screw around with heap allocations. Concretely, `Antichain` and `ChangeBatch` use them. This PR adds columnar support for the type. It is basically identical to `Vec`; it doesn't call `shrink_to_fit` for example, but the caller could do that themselves.