### PR TITLE
Reborrow for containers and references

### DIFF
--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -494,9 +494,7 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = #c_ident;
             #[inline(always)]
-            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> {
-                thing
-            }
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> { thing }
         }
 
         impl ::columnar::Container<#name> for #c_ident {
@@ -1124,9 +1122,7 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = #c_ident;
             #[inline(always)]
-            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> {
-                thing
-            }
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> { thing }
         }
 
         impl<CV: ::columnar::Container<u8>> ::columnar::Container<#name> for #c_ident <CV> {

--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -356,6 +356,12 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
                     #into_self
                 }
                 type Container = #c_ident < #(<#types as ::columnar::Columnar>::Container ),* >;
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> {
+                    #r_ident {
+                        #( #names: <#types as ::columnar::Columnar>::reborrow(thing.#names), )*
+                    }
+                }
             }
 
             impl #impl_gen ::columnar::Container<#name #ty_gen> for #c_ident < #(<#types as ::columnar::Columnar>::Container ),* > #where_clause2 {
@@ -364,6 +370,12 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
                 fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
                     #c_ident {
                         #( #names: <<#types as ::columnar::Columnar>::Container as ::columnar::Container<#types>>::borrow(&self.#names), )*
+                    }
+                }
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> {
+                    #c_ident {
+                        #( #names: <<#types as ::columnar::Columnar>::Container as ::columnar::Container<#types>>::reborrow(thing.#names), )*
                     }
                 }
             }
@@ -481,6 +493,10 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             #[inline(always)]
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = #c_ident;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> {
+                thing
+            }
         }
 
         impl ::columnar::Container<#name> for #c_ident {
@@ -488,6 +504,10 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             #[inline(always)]
             fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
                 #c_ident { count: &self.count }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> {
+                #c_ident { count: thing.count }
             }
         }
 
@@ -911,6 +931,25 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
             }
         }).collect::<Vec<_>>();
 
+        // For each variant, the reborrow case.
+        let reborrow = variants.iter().enumerate().map(|(index, (variant, types))| {
+
+            if data_enum.variants[index].fields == syn::Fields::Unit {
+                quote! { #r_ident::#variant(inner) => #r_ident::#variant(inner), }
+            }
+            else {
+                let temp_names = &types.iter().enumerate().map(|(index, _)| {
+                    let new_name = format!("t{}", index);
+                    syn::Ident::new(&new_name, variant.span())
+                }).collect::<Vec<_>>();
+
+                quote! {
+                    #r_ident::#variant(( #( #temp_names ),* )) => {
+                        #r_ident::#variant(( #( <(#types) as ::columnar::Columnar>::reborrow(#temp_names) ),* ))
+                    },
+                }
+            }
+        }).collect::<Vec<_>>();
 
         quote! {
             impl #impl_gen ::columnar::Columnar for #name #ty_gen #where_clause2 {
@@ -929,6 +968,12 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
                     }
                 }
                 type Container = #c_ident < #(#container_types),* >;
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> {
+                    match thing {
+                        #( #reborrow )*
+                    }
+                }
             }
 
             impl #impl_gen ::columnar::Container<#name #ty_gen> for #c_ident < #(#container_types),* > #where_clause2 {
@@ -939,6 +984,14 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
                         #(#names: self.#names.borrow(),)*
                         variant: self.variant.borrow(),
                         offset: self.offset.borrow(),
+                    }
+                }
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> {
+                    #c_ident {
+                        #(#names: <#container_types as ::columnar::Container<#variant_types>>::reborrow(thing.#names),)*
+                        variant: <Vec<u8> as ::columnar::Container<u8>>::reborrow(thing.variant),
+                        offset: <Vec<u64> as ::columnar::Container<u64>>::reborrow(thing.offset),
                     }
                 }
             }
@@ -1070,6 +1123,10 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             #[inline(always)]
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = #c_ident;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> {
+                thing
+            }
         }
 
         impl<CV: ::columnar::Container<u8>> ::columnar::Container<#name> for #c_ident <CV> {
@@ -1078,6 +1135,12 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
                 #c_ident {
                     variant: self.variant.borrow()
+                }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> {
+                #c_ident {
+                    variant: <CV as ::columnar::Container<u8>>::reborrow(thing.variant),
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ pub trait Columnar : 'static {
         }
         columns
     }
+
+    fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a;
 }
 
 /// A container that can hold `C`, and provide its preferred references.
@@ -67,6 +69,8 @@ pub trait Container<C: Columnar + ?Sized> {
     type Borrowed<'a>: Copy + Len + AsBytes<'a> + FromBytes<'a> + Index<Ref = C::Ref<'a>> where Self: 'a;
     /// Converts a reference to the type to a borrowed variant.
     fn borrow<'a>(&'a self) -> Self::Borrowed<'a>;
+
+    fn reborrow<'b, 'a: 'b>(item: Self::Borrowed<'a>) -> Self::Borrowed<'b> where Self: 'a;
 }
 
 pub use common::{Clear, Len, Push, IndexMut, Index, IndexAs, HeapSize, Slice, AsBytes, FromBytes};
@@ -336,6 +340,18 @@ pub mod common {
             Self { lower, upper, slice }
         }
         pub fn len(&self) -> usize { self.upper - self.lower }
+
+        /// Map the slice to another type.
+        pub(crate) fn map<T, F>(self, f: F) -> Slice<T>
+        where
+            F: Fn(S) -> T,
+        {
+            Slice {
+                lower: self.lower,
+                upper: self.upper,
+                slice: f(self.slice),
+            }
+        }
     }
 
     impl<S: Index> PartialEq for Slice<S> where S::Ref: PartialEq {
@@ -846,11 +862,19 @@ pub mod primitive {
                 fn into_owned<'a>(other: Self::Ref<'a>) -> Self { *other }
 
                 type Container = Vec<$index_type>;
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                    thing
+                }
             }
             impl crate::Container<$index_type> for Vec<$index_type> {
                 type Borrowed<'a> = &'a [$index_type];
                 #[inline(always)]
                 fn borrow<'a>(&'a self) -> Self::Borrowed<'a> { &self[..] }
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: &'a [$index_type]) -> Self::Borrowed<'b> where Self: 'a {
+                    &thing[..]
+                }
             }
 
             impl crate::HeapSize for $index_type { }
@@ -890,12 +914,20 @@ pub mod primitive {
             type Ref<'a> = usize;
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = Usizes;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                thing
+            }
         }
 
         impl<CV: crate::Container<u64>> crate::Container<usize> for Usizes<CV> {
             type Borrowed<'a> = Usizes<CV::Borrowed<'a>> where CV: 'a;
             fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
                 Usizes { values: self.values.borrow() }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where CV: 'a {
+                Usizes { values: CV::reborrow(thing.values) }
             }
         }
 
@@ -950,12 +982,20 @@ pub mod primitive {
             type Ref<'a> = isize;
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = Isizes;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                thing
+            }
         }
 
         impl<CV: crate::Container<i64>> crate::Container<isize> for Isizes<CV> {
             type Borrowed<'a> = Isizes<CV::Borrowed<'a>> where CV: 'a;
             fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
                 Isizes { values: self.values.borrow() }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where CV: 'a {
+                Isizes { values: CV::reborrow(thing.values) }
             }
         }
 
@@ -1018,12 +1058,20 @@ pub mod primitive {
             #[inline(always)]
             fn into_owned<'a>(_other: Self::Ref<'a>) -> Self { () }
             type Container = Empties;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                thing
+            }
         }
 
         impl crate::Container<()> for Empties {
             type Borrowed<'a> = Empties<&'a u64>;
             #[inline(always)]
             fn borrow<'a>(&'a self) -> Self::Borrowed<'a> { Empties { count: &self.count, empty: () } }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where Self: 'a {
+                Empties { count: thing.count, empty: () }
+            }
         }
 
         impl<CC: CopyAs<u64> + Copy> Len for Empties<CC> {
@@ -1109,6 +1157,10 @@ pub mod primitive {
             #[inline(always)]
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = Bools;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                thing
+            }
         }
 
         impl<VC: crate::Container<u64>> crate::Container<bool> for Bools<VC> {
@@ -1119,6 +1171,14 @@ pub mod primitive {
                     values: self.values.borrow(),
                     last_word: &self.last_word,
                     last_bits: &self.last_bits,
+                }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where VC: 'a {
+                Bools {
+                    values: VC::reborrow(thing.values),
+                    last_word: thing.last_word,
+                    last_bits: thing.last_bits,
                 }
             }
         }
@@ -1224,6 +1284,10 @@ pub mod primitive {
             #[inline(always)]
             fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other }
             type Container = Durations;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                thing
+            }
         }
 
         impl<SC: crate::Container<u64>, NC: crate::Container<u32>> crate::Container<Duration> for Durations<SC, NC> {
@@ -1233,6 +1297,13 @@ pub mod primitive {
                 Durations {
                     seconds: self.seconds.borrow(),
                     nanoseconds: self.nanoseconds.borrow(),
+                }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where SC: 'a, NC: 'a {
+                Durations {
+                    seconds: SC::reborrow(thing.seconds),
+                    nanoseconds: NC::reborrow(thing.nanoseconds),
                 }
             }
         }
@@ -1328,6 +1399,10 @@ pub mod string {
         #[inline(always)]
         fn into_owned<'a>(other: Self::Ref<'a>) -> Self { other.to_string() }
         type Container = Strings;
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+            thing
+        }
     }
 
     impl<'b, BC: crate::Container<u64>> crate::Container<String> for Strings<BC, &'b [u8]> {
@@ -1339,6 +1414,13 @@ pub mod string {
                 values: self.values,
             }
         }
+        #[inline(always)]
+        fn reborrow<'c, 'a: 'c>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'c> where BC: 'a, 'b: 'a {
+            Strings {
+                bounds: BC::reborrow(thing.bounds),
+                values: thing.values,
+            }
+        }
     }
     impl<BC: crate::Container<u64>> crate::Container<String> for Strings<BC, Vec<u8>> {
         type Borrowed<'a> = Strings<BC::Borrowed<'a>, &'a [u8]> where BC: 'a;
@@ -1347,6 +1429,13 @@ pub mod string {
             Strings {
                 bounds: self.bounds.borrow(),
                 values: self.values.borrow(),
+            }
+        }
+        #[inline(always)]
+        fn reborrow<'c, 'a: 'c>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'c> where BC: 'a {
+            Strings {
+                bounds: BC::reborrow(thing.bounds),
+                values: thing.values,
             }
         }
     }
@@ -1468,6 +1557,10 @@ pub mod vector {
             other.into_iter().map(|x| T::into_owned(x)).collect()
         }
         type Container = Vecs<T::Container>;
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+            thing.map(|x| <T::Container as crate::Container<T>>::reborrow(x))
+        }
     }
 
     impl<T: Columnar, const N: usize> Columnar for [T; N] {
@@ -1487,6 +1580,10 @@ pub mod vector {
             }
         }
         type Container = Vecs<T::Container>;
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+            thing.map(|x| <T::Container as crate::Container<T>>::reborrow(x))
+        }
     }
 
     impl<T: Columnar, const N: usize> Columnar for smallvec::SmallVec<[T; N]> {
@@ -1507,6 +1604,10 @@ pub mod vector {
             other.into_iter().map(|x| T::into_owned(x)).collect()
         }
         type Container = Vecs<T::Container>;
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+            thing.map(|x| <T::Container as crate::Container<T>>::reborrow(x))
+        }
     }
 
     impl<T: Columnar<Container = TC>, BC: crate::Container<u64>, TC: crate::Container<T>> crate::Container<Vec<T>> for Vecs<TC, BC> {
@@ -1516,6 +1617,13 @@ pub mod vector {
             Vecs {
                 bounds: self.bounds.borrow(),
                 values: self.values.borrow(),
+            }
+        }
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where BC: 'a, TC: 'a {
+            Vecs {
+                bounds: BC::reborrow(thing.bounds),
+                values: TC::reborrow(thing.values),
             }
         }
     }
@@ -1529,6 +1637,13 @@ pub mod vector {
                 values: self.values.borrow(),
             }
         }
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where BC: 'a, TC: 'a {
+            Vecs {
+                bounds: BC::reborrow(thing.bounds),
+                values: TC::reborrow(thing.values),
+            }
+        }
     }
 
     impl<T: Columnar<Container = TC>, BC: crate::Container<u64>, TC: crate::Container<T>, const N: usize> crate::Container<smallvec::SmallVec<[T; N]>> for Vecs<TC, BC> {
@@ -1538,6 +1653,13 @@ pub mod vector {
             Vecs {
                 bounds: self.bounds.borrow(),
                 values: self.values.borrow(),
+            }
+        }
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where BC: 'a, TC: 'a {
+            Vecs {
+                bounds: BC::reborrow(thing.bounds),
+                values: TC::reborrow(thing.values),
             }
         }
     }
@@ -1649,6 +1771,11 @@ pub mod tuple {
                     ($($name::into_owned($name2),)*)
                 }
                 type Container = ($($name::Container,)*);
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                    let ($($name,)*) = thing;
+                    ($($name::reborrow($name),)*)
+                }
             }
             impl<$($name: crate::Columnar, $name2: crate::Container<$name>,)*> crate::Container<($($name,)*)> for ($($name2,)*) {
                 type Borrowed<'a> = ($($name2::Borrowed<'a>,)*) where $($name: 'a, $name2: 'a,)*;
@@ -1656,6 +1783,11 @@ pub mod tuple {
                 fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
                     let ($($name,)*) = self;
                     ($($name.borrow(),)*)
+                }
+                #[inline(always)]
+                fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where $($name2: 'a,)* {
+                    let ($($name,)*) = thing;
+                    ($($name2::reborrow($name),)*)
                 }
             }
 
@@ -1831,6 +1963,14 @@ pub mod sums {
                     values: self.values.borrow(),
                 }
             }
+            #[inline(always)]
+            pub fn reborrow<'b, 'a: 'b>(thing: RankSelect<CC::Borrowed<'a>, VC::Borrowed<'a>, &'a u64>) -> RankSelect<CC::Borrowed<'b>, VC::Borrowed<'b>, &'b u64> {
+                use crate::Container;
+                RankSelect {
+                    counts: CC::reborrow(thing.counts),
+                    values: Bools::<VC, u64>::reborrow(thing.values),
+                }
+            }
         }
 
         impl<'a, CC: crate::AsBytes<'a>, VC: crate::AsBytes<'a>> crate::AsBytes<'a> for RankSelect<CC, VC, &'a u64> {
@@ -1973,6 +2113,13 @@ pub mod sums {
                 }
             }
             type Container = Results<S::Container, T::Container>;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                match thing {
+                    Ok(y) => Ok(S::reborrow(y)),
+                    Err(y) => Err(T::reborrow(y)),
+                }
+            }
         }
 
         impl<S: Columnar, T: Columnar, SC: crate::Container<S>, TC: crate::Container<T>> crate::Container<Result<S, T>> for Results<SC, TC> {
@@ -1982,6 +2129,14 @@ pub mod sums {
                     indexes: self.indexes.borrow(),
                     oks: self.oks.borrow(),
                     errs: self.errs.borrow(),
+                }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where SC: 'a, TC: 'a {
+                Results {
+                    indexes: RankSelect::<Vec<u64>, Vec<u64>>::reborrow(thing.indexes),
+                    oks: SC::reborrow(thing.oks),
+                    errs: TC::reborrow(thing.errs),
                 }
             }
         }
@@ -2181,6 +2336,13 @@ pub mod sums {
                 other.map(|x| T::into_owned(x))
             }
             type Container = Options<T::Container>;
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
+                match thing {
+                    Some(y) => Some(T::reborrow(y)),
+                    None => None,
+                }
+            }
         }
 
         impl<T: Columnar, TC: crate::Container<T>> crate::Container<Option<T>> for Options<TC> {
@@ -2189,6 +2351,13 @@ pub mod sums {
                 Options {
                     indexes: self.indexes.borrow(),
                     somes: self.somes.borrow(),
+                }
+            }
+            #[inline(always)]
+            fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where TC: 'a {
+                Options {
+                    indexes: RankSelect::<Vec<u64>, Vec<u64>>::reborrow(thing.indexes),
+                    somes: TC::reborrow(thing.somes),
                 }
             }
         }


### PR DESCRIPTION
Add a `reborrow` function to containers and references to safely adjust lifetimes.
