### PR TITLE
Trait refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - windows
         toolchain:
           - stable
-          - 1.78
+          - 1.79
     name: cargo test on ${{ matrix.os }}, rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -71,7 +71,7 @@ fn goser_decode(b: &mut Bencher) {
     b.bytes = 8 * words.len() as u64;
     b.iter(|| {
         let mut slices = Sequence::decode(&mut words);
-        let foo = <<Log as Columnar>::Container as Container<Log>>::Borrowed::from_bytes(&mut slices);
+        let foo = <<Log as Columnar>::Container as Container>::Borrowed::from_bytes(&mut slices);
         bencher::black_box(foo);
     });
 }

--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -1045,11 +1045,11 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             pub variant: CVar,
         }
 
-        impl ::columnar::Push<#name> for #c_ident {
+        impl<CV: ::columnar::Container<u8>> ::columnar::Push<#name> for #c_ident<CV> {
             #[inline]
             fn push(&mut self, item: #name) {
                 match item {
-                    #( #name::#names => self.variant.push(#indices), )*
+                    #( #name::#names => self.variant.push(&#indices), )*
                 }
             }
         }

--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -1054,7 +1054,7 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             pub variant: CVar,
         }
 
-        impl<CV: for<'a> ::columnar::Container<Ref<'a> = &'a u8>> ::columnar::Push<#name> for #c_ident<CV> {
+        impl<CV: ::columnar::common::PushIndexAs<u8>> ::columnar::Push<#name> for #c_ident<CV> {
             #[inline]
             fn push(&mut self, item: #name) {
                 match item {
@@ -1134,7 +1134,7 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> { thing }
         }
 
-        impl<CV: for<'a> ::columnar::Container<Ref<'a> = &'a u8>> ::columnar::Container for #c_ident <CV> {
+        impl<CV: ::columnar::common::PushIndexAs<u8>> ::columnar::Container for #c_ident <CV> {
             type Ref<'a> = #name;
             type Borrowed<'a> = #c_ident < CV::Borrowed<'a> > where CV: 'a;
             #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub trait Columnar : 'static {
     ///
     /// The container must support pushing both `&Self` and `Self::Ref<'_>`.
     /// In our running example this might be `(Vec<A>, Vecs<Vec<B>>)`.
-    type Container: Len + Clear + Default + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self> + Clone;
+    type Container: Len + Clear + Default + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
 
     /// Converts a sequence of the references to the type into columnar form.
     fn as_columns<'a, I>(selves: I) -> Self::Container where I: IntoIterator<Item =&'a Self>, Self: 'a {
@@ -70,7 +70,7 @@ pub trait Columnar : 'static {
 /// A container that can hold `C`, and provide its preferred references.
 ///
 /// As an example, `(Vec<A>, Vecs<Vec<B>>)`.
-pub trait Container<C: Columnar + ?Sized> : Send {
+pub trait Container<C: Columnar + ?Sized> : Clone + Send {
     /// The type of a borrowed container.
     ///
     /// Corresponding to our example, `(&'a [A], Vecs<&'a [B], &'a [u64]>)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub trait Columnar : 'static {
     ///
     /// The container must support pushing both `&Self` and `Self::Ref<'_>`.
     /// In our running example this might be `(Vec<A>, Vecs<Vec<B>>)`.
-    type Container: Clear + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
+    type Container: for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
 
     /// Converts a sequence of the references to the type into columnar form.
     fn as_columns<'a, I>(selves: I) -> Self::Container where I: IntoIterator<Item =&'a Self>, Self: 'a {
@@ -70,7 +70,7 @@ pub trait Columnar : 'static {
 /// A container that can hold `C`, and provide its preferred references.
 ///
 /// As an example, `(Vec<A>, Vecs<Vec<B>>)`.
-pub trait Container<C: Columnar + ?Sized> : Len + Clone + Default + Send {
+pub trait Container<C: Columnar + ?Sized> : Len + Clear + Clone + Default + Send {
     /// The type of a borrowed container.
     ///
     /// Corresponding to our example, `(&'a [A], Vecs<&'a [B], &'a [u64]>)`.
@@ -1729,7 +1729,7 @@ pub mod vector {
         }
     }
 
-    impl<TC: Clear> Clear for Vecs<TC> {
+    impl<TC: Clear, BC: Clear> Clear for Vecs<TC, BC> {
         #[inline(always)]
         fn clear(&mut self) {
             self.bounds.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub trait Columnar : 'static {
     ///
     /// The container must support pushing both `&Self` and `Self::Ref<'_>`.
     /// In our running example this might be `(Vec<A>, Vecs<Vec<B>>)`.
-    type Container: Len + Clear + Default + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self> + Clone + Send;
+    type Container: Len + Clear + Default + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self> + Clone;
 
     /// Converts a sequence of the references to the type into columnar form.
     fn as_columns<'a, I>(selves: I) -> Self::Container where I: IntoIterator<Item =&'a Self>, Self: 'a {
@@ -70,7 +70,7 @@ pub trait Columnar : 'static {
 /// A container that can hold `C`, and provide its preferred references.
 ///
 /// As an example, `(Vec<A>, Vecs<Vec<B>>)`.
-pub trait Container<C: Columnar + ?Sized> {
+pub trait Container<C: Columnar + ?Sized> : Send {
     /// The type of a borrowed container.
     ///
     /// Corresponding to our example, `(&'a [A], Vecs<&'a [B], &'a [u64]>)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub trait Columnar : 'static {
     ///
     /// The container must support pushing both `&Self` and `Self::Ref<'_>`.
     /// In our running example this might be `(Vec<A>, Vecs<Vec<B>>)`.
-    type Container: Len + Clear + Default + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
+    type Container: Len + Clear + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
 
     /// Converts a sequence of the references to the type into columnar form.
     fn as_columns<'a, I>(selves: I) -> Self::Container where I: IntoIterator<Item =&'a Self>, Self: 'a {
@@ -70,7 +70,7 @@ pub trait Columnar : 'static {
 /// A container that can hold `C`, and provide its preferred references.
 ///
 /// As an example, `(Vec<A>, Vecs<Vec<B>>)`.
-pub trait Container<C: Columnar + ?Sized> : Clone + Send {
+pub trait Container<C: Columnar + ?Sized> : Clone + Default + Send {
     /// The type of a borrowed container.
     ///
     /// Corresponding to our example, `(&'a [A], Vecs<&'a [B], &'a [u64]>)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub trait Columnar : 'static {
     ///
     /// The container must support pushing both `&Self` and `Self::Ref<'_>`.
     /// In our running example this might be `(Vec<A>, Vecs<Vec<B>>)`.
-    type Container: Len + Clear + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
+    type Container: Clear + for<'a> Push<&'a Self> + for<'a> Push<Self::Ref<'a>> + Container<Self>;
 
     /// Converts a sequence of the references to the type into columnar form.
     fn as_columns<'a, I>(selves: I) -> Self::Container where I: IntoIterator<Item =&'a Self>, Self: 'a {
@@ -70,7 +70,7 @@ pub trait Columnar : 'static {
 /// A container that can hold `C`, and provide its preferred references.
 ///
 /// As an example, `(Vec<A>, Vecs<Vec<B>>)`.
-pub trait Container<C: Columnar + ?Sized> : Clone + Default + Send {
+pub trait Container<C: Columnar + ?Sized> : Len + Clone + Default + Send {
     /// The type of a borrowed container.
     ///
     /// Corresponding to our example, `(&'a [A], Vecs<&'a [B], &'a [u64]>)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,7 +931,7 @@ pub mod primitive {
             }
             #[inline(always)]
             fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where CV: 'a {
-                Usizes { values: <CV as Container>::reborrow(thing.values) }
+                Usizes { values: CV::reborrow(thing.values) }
             }
         }
 
@@ -998,7 +998,7 @@ pub mod primitive {
             }
             #[inline(always)]
             fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where CV: 'a {
-                Isizes { values: <CV as Container>::reborrow(thing.values) }
+                Isizes { values: CV::reborrow(thing.values) }
             }
         }
 
@@ -1177,7 +1177,7 @@ pub mod primitive {
             #[inline(always)]
             fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where VC: 'a {
                 Bools {
-                    values: <VC as Container>::reborrow(thing.values),
+                    values: VC::reborrow(thing.values),
                     last_word: thing.last_word,
                     last_bits: thing.last_bits,
                 }
@@ -1302,8 +1302,8 @@ pub mod primitive {
             #[inline(always)]
             fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where SC: 'a, NC: 'a {
                 Durations {
-                    seconds: <SC as Container>::reborrow(thing.seconds),
-                    nanoseconds: <NC as Container>::reborrow(thing.nanoseconds),
+                    seconds: SC::reborrow(thing.seconds),
+                    nanoseconds: NC::reborrow(thing.nanoseconds),
                 }
             }
         }
@@ -1416,7 +1416,7 @@ pub mod string {
         #[inline(always)]
         fn reborrow<'c, 'a: 'c>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'c> where BC: 'a {
             Strings {
-                bounds: <BC as Container>::reborrow(thing.bounds),
+                bounds: BC::reborrow(thing.bounds),
                 values: thing.values,
             }
         }
@@ -1553,7 +1553,7 @@ pub mod vector {
         type Container = Vecs<T::Container>;
         #[inline(always)]
         fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
-            thing.map(|x| <T::Container as Container>::reborrow(x))
+            thing.map(|x| T::Container::reborrow(x))
         }
     }
 
@@ -1576,7 +1576,7 @@ pub mod vector {
         type Container = Vecs<T::Container>;
         #[inline(always)]
         fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
-            thing.map(|x| <T::Container as Container>::reborrow(x))
+            thing.map(|x| T::Container::reborrow(x))
         }
     }
 
@@ -1600,7 +1600,7 @@ pub mod vector {
         type Container = Vecs<T::Container>;
         #[inline(always)]
         fn reborrow<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a {
-            thing.map(|x| <T::Container as Container>::reborrow(x))
+            thing.map(|x| T::Container::reborrow(x))
         }
     }
 
@@ -1617,7 +1617,7 @@ pub mod vector {
         #[inline(always)]
         fn reborrow<'b, 'a: 'b>(thing: Self::Borrowed<'a>) -> Self::Borrowed<'b> where BC: 'a, TC: 'a {
             Vecs {
-                bounds: <BC as Container>::reborrow(thing.bounds),
+                bounds: BC::reborrow(thing.bounds),
                 values: TC::reborrow(thing.values),
             }
         }
@@ -1925,8 +1925,8 @@ pub mod sums {
             #[inline(always)]
             pub fn reborrow<'b, 'a: 'b>(thing: RankSelect<CC::Borrowed<'a>, VC::Borrowed<'a>, &'a u64>) -> RankSelect<CC::Borrowed<'b>, VC::Borrowed<'b>, &'b u64> {
                 RankSelect {
-                    counts: <CC as Container>::reborrow(thing.counts),
-                    values: <Bools::<VC, u64> as Container>::reborrow(thing.values),
+                    counts: CC::reborrow(thing.counts),
+                    values: Bools::<VC, u64>::reborrow(thing.values),
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,14 +60,14 @@ fn main() {
     // Borrow raw bytes from `columns`, and reconstruct a borrowed `columns`.
     // In practice, we would use serialized bytes from somewhere else.
     // This local function gives type support, relating `T` to `T::Borrowed`.
-    fn round_trip<'a, C: Columnar>(container: &'a C::Container) -> <C::Container as Container<C>>::Borrowed<'a> {
+    fn round_trip<'a, C: Container>(container: &'a C) -> C::Borrowed<'a> {
         // Grab a reference to underlying bytes, as if serialized.
         let borrow = container.borrow();
         let mut bytes_iter = borrow.as_bytes().map(|(_, bytes)| bytes);
         columnar::FromBytes::from_bytes(&mut bytes_iter)
     }
 
-    let borrowed = round_trip::<Group<_>>(&columns);
+    let borrowed = round_trip(&columns);
 
     // Project down to columns and variants using field accessors.
     // This gets all ages from people in teams.


### PR DESCRIPTION
This PR proposes to pivot the `Container<C: Columnar>` trait to one that does not have a `C` argument.

The intent is that containers and everything downward from them have no opinions about `C` and only used its GAT `C::Ref<'a>` as the glue that holds various associated types together. However, the parameter has meant that to use a container you would have to first know a columnar type that gives rise to it, even if you don't care about that type. Additionally, the multiple `Container` implementations made it cumbersome to type `.borrow()` because .. a concrete type could potentially have any number of `Container<_>` implementations. Generally, it seems like each container is fully defined even in the absence of a `C: Columnar`.

The `main.rs` example got a bit easier, because it struggled with type inference to determine the columnar type that would give rise to the columns at hand, but reframing its bounds in terms of containers everything was unambiguous. I'm hopeful that similar simplifications happen elsewhere.

The change comes with a few risks. 

* Without the argument it is possible that a container might have wanted two `Container` implementations, but now cannot. This is true, but there is always the potential to use wrapper types, and generally we haven't seen instances of one type that wants two `Container` implementations.
* I had a few moments where I had to be more explicit than I realized, for example replacing `C: Container<u64>` required the explicit statement that `Ref<'a> = &'a u64`, which seems overly prescriptive. It seemed that Rust struggled to draw some connections that seemed clear to me, but perhaps (likely) I was mistaken.
* I barely understand the derive macro at this point, and while the tests build I'm not sure how deep their coverage goes. Generally, the `Container` implementations depend on the type's generic arguments *less*, usually not at all.

The `Container` trait now requires various other traits that were imposed on the associated type of the `Columnar` implementor, which means that there is some work to do around `Container` implementations, generally ensuring that they implement things like `Len` and `Clear` for all generic containers referenced in the `Container` implementation, not just the default ones that the `Columnar` implementor might have chosen. This clean-up repeated itself a few times, but became mechanical.