### PR TITLE
Add `Container::extend_from_self`

### DIFF
--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -379,6 +379,11 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
                         #( #names: <#container_types as ::columnar::Container>::reborrow_ref(thing.#names), )*
                     }
                 }
+
+                #[inline(always)]
+                fn extend_from_self(&mut self, other: Self::Borrowed<'_>, range: std::ops::Range<usize>) {
+                    #( self.#names.extend_from_self(other.#names, range.clone()); )*
+                }
             }
         }
     };
@@ -509,6 +514,11 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             }
             #[inline(always)]
             fn reborrow_ref<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> { thing }
+
+            #[inline(always)]
+            fn extend_from_self(&mut self, _other: Self::Borrowed<'_>, range: std::ops::Range<usize>) {
+                self.count += range.len() as u64;
+            }         
         }
 
     }.into()
@@ -990,6 +1000,8 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
                         #( #reborrow_ref )*
                     }
                 }
+
+                // TODO: implement `extend_from_self`.
             }
         }
     };
@@ -1138,6 +1150,8 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             }
             #[inline(always)]
             fn reborrow_ref<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> { thing }
+
+            // TODO: implement `extend_from_self`.
         }
     }.into()
 }


### PR DESCRIPTION
This PR adds an `extend_from_self` method to `Container`, which accepts a borrowed container argument and a `usize` range. The intent is that the method should copy the range of the borrowed container into `self`, though it can often do so more efficiently than element at a time. In particular, the underlying allocations for many of these types are themselves contiguous vectors and slices, and the extension instructions can make their way down to these containers.

The PR also has a few additional `#[inline(always)]` annotations that seemed to be missing.

The PR does not contain the logic for `derive(Columnar)` when applied to `enum` types. It seems not that hard,  but more challenging than for `struct` types. I have left two `// TODO` comments where they could be implemented.