### PR TITLE
Tidy/optimize `extend_from_self`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1483,9 +1483,14 @@ pub mod string {
                 self.values.extend_from_self(other.values, other_lower as usize .. other_upper as usize);
 
                 // Each bound needs to be shifted by `values_len - other_lower`.
-                for index in range {
-                    let shifted = other.bounds.index_as(index) - other_lower + values_len;
-                    self.bounds.push(&shifted)
+                if values_len == other_lower {
+                    self.bounds.extend_from_self(other.bounds, range);
+                }
+                else {
+                    for index in range {
+                        let shifted = other.bounds.index_as(index) - other_lower + values_len;
+                        self.bounds.push(&shifted)
+                    }
                 }
             }
         }
@@ -1695,9 +1700,14 @@ pub mod vector {
                 self.values.extend_from_self(other.values, other_lower as usize .. other_upper as usize);
 
                 // Each bound needs to be shifted by `values_len - other_lower`.
-                for index in range {
-                    let shifted = other.bounds.index_as(index) - other_lower + values_len;
-                    self.bounds.push(&shifted)
+                if values_len == other_lower {
+                    self.bounds.extend_from_self(other.bounds, range);
+                }
+                else {
+                    for index in range {
+                        let shifted = other.bounds.index_as(index) - other_lower + values_len;
+                        self.bounds.push(&shifted)
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1475,20 +1475,17 @@ pub mod string {
         fn extend_from_self(&mut self, other: Self::Borrowed<'_>, range: std::ops::Range<usize>) {
             if !range.is_empty() {
                 // Imported bounds will be relative to this starting offset.
-                let mut values_len = self.values.len() as u64;
+                let values_len = self.values.len() as u64;
 
                 // Push all bytes that we can, all at once.
-                let other_lower: usize = if range.start == 0 { 0 } else { other.bounds.index_as(range.start-1) } as usize;
-                let other_upper: usize = other.bounds.index_as(range.end-1) as usize;
+                let other_lower = if range.start == 0 { 0 } else { other.bounds.index_as(range.start-1) };
+                let other_upper = other.bounds.index_as(range.end-1);
                 self.values.extend_from_self(other.values, other_lower as usize .. other_upper as usize);
 
-                // Determine new bounds to push based on lengths, relative to `values_len`.
-                let mut lower = other_lower as u64;
+                // Each bound needs to be shifted by `values_len - other_lower`.
                 for index in range {
-                    let upper = other.bounds.index_as(index);
-                    values_len += upper - lower;
-                    self.bounds.push(&values_len);
-                    lower = upper;
+                    let shifted = other.bounds.index_as(index) - other_lower + values_len;
+                    self.bounds.push(&shifted)
                 }
             }
         }
@@ -1690,20 +1687,17 @@ pub mod vector {
         fn extend_from_self(&mut self, other: Self::Borrowed<'_>, range: std::ops::Range<usize>) {
             if !range.is_empty() {
                 // Imported bounds will be relative to this starting offset.
-                let mut values_len = self.values.len() as u64;
+                let values_len = self.values.len() as u64;
 
                 // Push all bytes that we can, all at once.
-                let other_lower: usize = if range.start == 0 { 0 } else { other.bounds.index_as(range.start-1) } as usize;
-                let other_upper: usize = other.bounds.index_as(range.end-1) as usize;
+                let other_lower = if range.start == 0 { 0 } else { other.bounds.index_as(range.start-1) };
+                let other_upper = other.bounds.index_as(range.end-1);
                 self.values.extend_from_self(other.values, other_lower as usize .. other_upper as usize);
 
-                // Determine new bounds to push based on lengths, relative to `values_len`.
-                let mut lower = other_lower as u64;
+                // Each bound needs to be shifted by `values_len - other_lower`.
                 for index in range {
-                    let upper = other.bounds.index_as(index);
-                    values_len += upper - lower;
-                    self.bounds.push(&values_len);
-                    lower = upper;
+                    let shifted = other.bounds.index_as(index) - other_lower + values_len;
+                    self.bounds.push(&shifted)
                 }
             }
         }


### PR DESCRIPTION
Some tidying around the `String` and `Vecs` implementations, to clarify that this is exactly the incoming bounds shifted by an amount. In the case that the shift is zero, use `extend_from_self`. This improves the benchmarks in an unrealistic manner, because the copying behavior means the offsets always end up zero. But, it reveals just how much time is spend adding some numbers to some other numbers. Quite a lot, as it turns out. It wouldn't be too hard to have a "relocatable" bounds representation, not unlike `RankSelect`, but that's for another day.

There's also a potentially substantial optimization for `Strings` and `Vecs` with fixed stride offsets. Even though there may be a translation, if all offsets are spaced a fixed amount then folding them in can be constant time (verify the spacing is the same; increment the count). I don't think the current pile of code supports this, but it might be worth exploring something where you could extend with a shift, or something like that. Or perhaps Rust/LLVM will crush it; we'll see!