### PR TITLE
Decouple container and bytes traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,10 @@ impl<T: Clone + Send + 'static> Container for Vec<T> {
     fn borrow<'a>(&'a self) -> Self::Borrowed<'a> { &self[..] }
     fn reborrow<'b, 'a: 'b>(item: Self::Borrowed<'a>) -> Self::Borrowed<'b> where Self: 'a { item }
     fn reborrow_ref<'b, 'a: 'b>(item: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a { item }
+    fn extend_from_self(&mut self, other: Self::Borrowed<'_>, range: std::ops::Range<usize>) {
+        self.extend_from_slice(&other[range])
+    }
+
 }
 
 /// A container that can also be viewed as and reconstituted from bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub trait Columnar : 'static {
     ///
     /// The container must support pushing both `&Self` and `Self::Ref<'_>`.
     /// In our running example this might be `(Vec<A>, Vecs<Vec<B>>)`.
-    type Container: Container + for<'a> Push<&'a Self>;
+    type Container: ContainerBytes + for<'a> Push<&'a Self>;
 
     /// Converts a sequence of the references to the type into columnar form.
     fn as_columns<'a, I>(selves: I) -> Self::Container where I: IntoIterator<Item=&'a Self>, Self: 'a {
@@ -85,7 +85,7 @@ pub trait Container : Len + Clear + for<'a> Push<Self::Ref<'a>> + Clone + Defaul
     /// The type of a borrowed container.
     ///
     /// Corresponding to our example, `(&'a [A], Vecs<&'a [B], &'a [u64]>)`.
-    type Borrowed<'a>: Copy + Len + AsBytes<'a> + FromBytes<'a> + Index<Ref = Self::Ref<'a>> where Self: 'a;
+    type Borrowed<'a>: Copy + Len + Index<Ref = Self::Ref<'a>> where Self: 'a;
     /// Converts a reference to the type to a borrowed variant.
     fn borrow<'a>(&'a self) -> Self::Borrowed<'a>;
     /// Reborrows the borrowed type to a shorter lifetime. See [`Columnar::reborrow`] for details.
@@ -103,6 +103,18 @@ pub trait Container : Len + Clear + for<'a> Push<Self::Ref<'a>> + Clone + Defaul
         self.extend(range.map(|i| other.get(i)))
     }
 }
+
+impl<T: Clone + Send + 'static> Container for Vec<T> {
+    type Ref<'a> = &'a T;
+    type Borrowed<'a> = &'a [T];
+    fn borrow<'a>(&'a self) -> Self::Borrowed<'a> { &self[..] }
+    fn reborrow<'b, 'a: 'b>(item: Self::Borrowed<'a>) -> Self::Borrowed<'b> where Self: 'a { item }
+    fn reborrow_ref<'b, 'a: 'b>(item: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a { item }
+}
+
+/// A container that can also be viewed as and reconstituted from bytes.
+pub trait ContainerBytes : for<'a> Container<Borrowed<'a> : AsBytes<'a> + FromBytes<'a>> { }
+impl<C: for<'a> Container<Borrowed<'a> : AsBytes<'a> + FromBytes<'a>>> ContainerBytes for C { }
 
 pub use common::{Clear, Len, Push, IndexMut, Index, IndexAs, HeapSize, Slice, AsBytes, FromBytes};
 /// Common traits and types that are re-used throughout the module.
@@ -909,19 +921,6 @@ pub mod primitive {
                 fn into_owned<'a>(other: crate::Ref<'a, Self>) -> Self { *other }
 
                 type Container = Vec<$index_type>;
-            }
-            impl crate::Container for Vec<$index_type> {
-                type Ref<'a> = &'a $index_type;
-                type Borrowed<'a> = &'a [$index_type];
-                #[inline(always)]
-                fn borrow<'a>(&'a self) -> Self::Borrowed<'a> { &self[..] }
-                #[inline(always)]
-                fn reborrow<'b, 'a: 'b>(thing: &'a [$index_type]) -> Self::Borrowed<'b> where Self: 'a { thing }
-                #[inline(always)]
-                fn reborrow_ref<'b, 'a: 'b>(thing: Self::Ref<'a>) -> Self::Ref<'b> where Self: 'a { thing }
-
-                #[inline(always)]
-                fn extend_from_self(&mut self, other: Self::Borrowed<'_>, range: std::ops::Range<usize>) { self.extend_from_slice(&other[range]) }
             }
 
             impl crate::HeapSize for $index_type { }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use columnar::{Columnar, Container};
+use columnar::{Columnar, Container, ContainerBytes};
 
 #[derive(Columnar)]
 enum Group<T> {
@@ -60,7 +60,7 @@ fn main() {
     // Borrow raw bytes from `columns`, and reconstruct a borrowed `columns`.
     // In practice, we would use serialized bytes from somewhere else.
     // This local function gives type support, relating `T` to `T::Borrowed`.
-    fn round_trip<'a, C: Container>(container: &'a C) -> C::Borrowed<'a> {
+    fn round_trip<'a, C: ContainerBytes>(container: &'a C) -> C::Borrowed<'a> {
         // Grab a reference to underlying bytes, as if serialized.
         let borrow = container.borrow();
         let mut bytes_iter = borrow.as_bytes().map(|(_, bytes)| bytes);
@@ -109,7 +109,7 @@ mod test {
         Foo,
         Bar,
     }
-    
+
     // Tests derived implementations for a unit struct.
     #[derive(Columnar, Debug, Copy, Clone)]
     struct Test5;
@@ -150,7 +150,7 @@ mod test {
             Test3::Bar(4),
         ];
         let test3c = columnar::Columnar::as_columns(test3s.iter());
-        
+
         println!("{:?}", test3c);
 
         let iterc = (&test3c).into_index_iter();


### PR DESCRIPTION
This PR proposes to decouple the `AsBytes` and `FromBytes` traits from the definition of `Container`, extending its definition to a new trait `ContainerBytes` which requires and implies that the `Borrowed<'a>` type implement these types for all `'a`.

This opens the door to implementing `Container` for all `T: Clone + Send + 'static`, which can make integrating columns easier, when one has a complex type not all of whose members fit the `columnar` rubric.

The necessary fix-ups were here limited to changing some type constraints from `C: Container` to `C: ContainerBytes`.