### PR TITLE
Bump versions to 09/03

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "columnar"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Conversion from arrays of complex structs to simple structs of arrays"
 edition = "2021"
@@ -19,7 +19,7 @@ members = ["columnar_derive"]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = { version = "1.13.2", features = ["const_generics"] }
 bytemuck = "1.20"
-columnar_derive = { path = "columnar_derive", version = "0.2" }
+columnar_derive = { path = "columnar_derive", version = "0.3" }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/columnar_derive/Cargo.toml
+++ b/columnar_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "columnar_derive"
-version = "0.2.7"
+version = "0.3.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Derive macros for columnar crate"
 edition = "2021"


### PR DESCRIPTION
Manual version intervention, as `release-plz` doesn't correctly bump the `columnar-derive` crate version.