### PR TITLE
Sync columnar and columnar_derive versions

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,13 @@
+# Release columnar and columnar_derive with the same version.
+#
+# This should prevent situations where release-plz doesn't
+# recognize semver-incompatible changes and only bumps the minor
+# version of the derive package.
+[[package]]
+name = "columnar"
+version_group = "columnar"
+
+[[package]]
+name = "columnar_derive"
+version_group = "columnar"
+


### PR DESCRIPTION
This should prevent invalid semver versions where columnar_derive looks compatible, but isn't.

Tested locally, and it bumps `columnar_derive` to `0.9.x`, tracking `columnar`.