### PR TITLE
Encode u128/u128 as [u8; 16]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["columnar_derive"]
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = { version = "1.13.2", features = ["const_generics"] }
-bytemuck = "1.20"
+bytemuck = { version = "1.20", features = ["min_const_generics"] }
 columnar_derive = { path = "columnar_derive", version = "0.10" }
 
 [dev-dependencies]


### PR DESCRIPTION
As it says on the box, encode u128/i128 as [u8; 16] to avoid alignment hassle.

We could rework it to a macro to support other odd types, too, but not doing that yet.
