### PR TITLE
Add structured decoding

### DIFF
--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -323,19 +323,6 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
                     Self { #(#names: ::columnar::FromBytes::from_bytes(bytes),)* }
                 }
                 #[inline(always)]
-                fn from_byte_slices(bytes: &[&'columnar [u8]]) -> Self {
-                    let mut _offset = 0;
-                    #(
-                        let #names = <#container_types>::from_byte_slices(&bytes[_offset .. _offset + <#container_types>::SLICE_COUNT]);
-                        _offset += <#container_types>::SLICE_COUNT;
-                    )*
-                    Self { #(#names,)* }
-                }
-                #[inline(always)]
-                fn from_u64s(words: &mut impl Iterator<Item=(&'columnar [u64], u8)>) -> Self {
-                    Self { #(#names: ::columnar::FromBytes::from_u64s(words),)* }
-                }
-                #[inline(always)]
                 fn from_store(store: &::columnar::bytes::indexed::DecodedStore<'columnar>, offset: &mut usize) -> Self {
                     Self { #(#names: ::columnar::FromBytes::from_store(store, offset),)* }
                 }
@@ -522,15 +509,6 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
             #[inline(always)]
             fn from_bytes(bytes: &mut impl Iterator<Item=&'columnar [u8]>) -> Self {
                 Self { count: &::columnar::bytemuck::try_cast_slice(bytes.next().unwrap()).unwrap()[0] }
-            }
-            #[inline(always)]
-            fn from_byte_slices(bytes: &[&'columnar [u8]]) -> Self {
-                Self { count: &::columnar::bytemuck::try_cast_slice(bytes[0]).unwrap()[0] }
-            }
-            #[inline(always)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'columnar [u64], u8)>) -> Self {
-                let (w, _tail) = words.next().expect("Iterator exhausted prematurely");
-                Self { count: &w[0] }
             }
             #[inline(always)]
             fn from_store(store: &::columnar::bytes::indexed::DecodedStore<'columnar>, offset: &mut usize) -> Self {
@@ -920,23 +898,6 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
                     }
                 }
                 #[inline(always)]
-                fn from_byte_slices(bytes: &[&'columnar [u8]]) -> Self {
-                    let mut _offset = 0;
-                    #(
-                        let #names = <#container_types>::from_byte_slices(&bytes[_offset .. _offset + <#container_types>::SLICE_COUNT]);
-                        _offset += <#container_types>::SLICE_COUNT;
-                    )*
-                    let indexes = <::columnar::Discriminant<CVar, COff, CC>>::from_byte_slices(&bytes[_offset ..]);
-                    Self { #(#names,)* indexes }
-                }
-                #[inline(always)]
-                fn from_u64s(words: &mut impl Iterator<Item=(&'columnar [u64], u8)>) -> Self {
-                    Self {
-                        #(#names: ::columnar::FromBytes::from_u64s(words),)*
-                        indexes: ::columnar::FromBytes::from_u64s(words),
-                    }
-                }
-                #[inline(always)]
                 fn from_store(store: &::columnar::bytes::indexed::DecodedStore<'columnar>, offset: &mut usize) -> Self {
                     Self {
                         #(#names: ::columnar::FromBytes::from_store(store, offset),)*
@@ -1231,14 +1192,6 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             #[inline(always)]
             fn from_bytes(bytes: &mut impl Iterator<Item=&'columnar [u8]>) -> Self {
                 Self { variant: ::columnar::FromBytes::from_bytes(bytes) }
-            }
-            #[inline(always)]
-            fn from_byte_slices(bytes: &[&'columnar [u8]]) -> Self {
-                Self { variant: CVar::from_byte_slices(bytes) }
-            }
-            #[inline(always)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'columnar [u64], u8)>) -> Self {
-                Self { variant: ::columnar::FromBytes::from_u64s(words) }
             }
             #[inline(always)]
             fn from_store(store: &::columnar::bytes::indexed::DecodedStore<'columnar>, offset: &mut usize) -> Self {

--- a/examples/decode_asm.rs
+++ b/examples/decode_asm.rs
@@ -1,11 +1,10 @@
 //! Assembly inspection for decode paths.
 //!
-//! Compares three approaches to accessing a single field of a k-tuple
-//! stored in Indexed-encoded `&[u64]` data:
+//! Compares two approaches to accessing a single field of a k-tuple
+//! stored in indexed-encoded `&[u64]` data:
 //!
 //! 1. `from_bytes` + `decode`: constructs all k fields, O(k)
-//! 2. `from_u64s` + `decode_u64s`: non-panicking, LLVM eliminates unused fields, O(1) in k
-//! 3. `decode_field` (random access): decodes one field directly, O(1) in k and j
+//! 2. `from_store` + `DecodedStore`: random access, LLVM eliminates unused fields, O(1)
 //!
 //! Build with: `cargo rustc --example decode_asm --release -- --emit asm`
 
@@ -36,183 +35,52 @@ use columnar::bytes::indexed;
 }
 
 // ================================================================
-// from_u64s path (non-panicking, LLVM eliminates unused fields)
-// ================================================================
-
-#[no_mangle] pub fn u64s_3_f0(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], &'a [u64], &'a [u64]);
-    T::from_u64s(&mut indexed::decode_u64s(store)).0[i]
-}
-#[no_mangle] pub fn u64s_3_flast(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], &'a [u64], &'a [u64]);
-    T::from_u64s(&mut indexed::decode_u64s(store)).2[i]
-}
-#[no_mangle] pub fn u64s_8_f0(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], &'a [u64], &'a [u64], &'a [u64],
-                   &'a [u64], &'a [u64], &'a [u64], &'a [u64]);
-    T::from_u64s(&mut indexed::decode_u64s(store)).0[i]
-}
-#[no_mangle] pub fn u64s_8_flast(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], &'a [u64], &'a [u64], &'a [u64],
-                   &'a [u64], &'a [u64], &'a [u64], &'a [u64]);
-    T::from_u64s(&mut indexed::decode_u64s(store)).7[i]
-}
-
-// ================================================================
-// Random access (decode one field directly, O(1) in both k and j)
-// ================================================================
-
-/// Decode field `k` directly from store as `(&[u64], u8)`.
-/// Each call is independent — no iterator state.
-#[inline(always)]
-fn decode_field(store: &[u64], k: usize) -> (&[u64], u8) {
-    let slices = store[0] as usize / 8 - 1;
-    let index = &store[..slices + 1];
-    let last = *index.last().unwrap_or(&0) as usize;
-    let last_w = (last + 7) / 8;
-    let words = &store[..last_w];
-    let upper = (*index.get(k + 1).unwrap_or(&0) as usize).min(last);
-    let lower = (((*index.get(k).unwrap_or(&0) as usize) + 7) & !7).min(upper);
-    let upper_w = ((upper + 7) / 8).min(words.len());
-    let lower_w = (lower / 8).min(upper_w);
-    let tail = (upper % 8) as u8;
-    (&words[lower_w..upper_w], tail)
-}
-
-#[no_mangle] pub fn field_3_f0(store: &[u64], i: usize) -> u64 {
-    decode_field(store, 0).0[i]
-}
-#[no_mangle] pub fn field_3_flast(store: &[u64], i: usize) -> u64 {
-    decode_field(store, 2).0[i]
-}
-#[no_mangle] pub fn field_8_f0(store: &[u64], i: usize) -> u64 {
-    decode_field(store, 0).0[i]
-}
-#[no_mangle] pub fn field_8_flast(store: &[u64], i: usize) -> u64 {
-    decode_field(store, 7).0[i]
-}
-
-// ================================================================
-// DecodedStore path (random access, no iterator)
+// DecodedStore path (random access, O(1) in both k and field position)
 // ================================================================
 
 #[no_mangle] pub fn store_3_f0(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], &'a [u64], &'a [u64]);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
+    let ds = indexed::DecodedStore::new(store);
     T::from_store(&ds, &mut 0).0[i]
 }
 #[no_mangle] pub fn store_3_flast(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], &'a [u64], &'a [u64]);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
+    let ds = indexed::DecodedStore::new(store);
     T::from_store(&ds, &mut 0).2[i]
 }
 #[no_mangle] pub fn store_8_f0(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], &'a [u64], &'a [u64], &'a [u64],
                    &'a [u64], &'a [u64], &'a [u64], &'a [u64]);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
+    let ds = indexed::DecodedStore::new(store);
     T::from_store(&ds, &mut 0).0[i]
 }
 #[no_mangle] pub fn store_8_flast(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], &'a [u64], &'a [u64], &'a [u64],
                    &'a [u64], &'a [u64], &'a [u64], &'a [u64]);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
+    let ds = indexed::DecodedStore::new(store);
     T::from_store(&ds, &mut 0).7[i]
-}
-
-// ================================================================
-// Scaling test: k=16 via nested (8, 8) tuple
-// ================================================================
-
-type T8<'a> = (&'a [u64], &'a [u64], &'a [u64], &'a [u64],
-               &'a [u64], &'a [u64], &'a [u64], &'a [u64]);
-
-// (T8, T8) = 16 fields. Field 0 is .0.0, field 7 is .0.7, field 8 is .1.0, field 15 is .1.7
-type T16<'a> = (T8<'a>, T8<'a>);
-
-#[no_mangle] pub fn store_16_f0(store: &[u64], i: usize) -> u64 {
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    T16::from_store(&ds, &mut 0).0.0[i]
-}
-#[no_mangle] pub fn store_16_f7(store: &[u64], i: usize) -> u64 {
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    T16::from_store(&ds, &mut 0).0.7[i]
-}
-#[no_mangle] pub fn store_16_f8(store: &[u64], i: usize) -> u64 {
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    T16::from_store(&ds, &mut 0).1.0[i]
-}
-#[no_mangle] pub fn store_16_flast(store: &[u64], i: usize) -> u64 {
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    T16::from_store(&ds, &mut 0).1.7[i]
-}
-
-// For comparison: iterator path at k=16
-#[no_mangle] pub fn u64s_16_f0(store: &[u64], i: usize) -> u64 {
-    T16::from_u64s(&mut columnar::bytes::indexed::decode_u64s(store)).0.0[i]
-}
-#[no_mangle] pub fn u64s_16_flast(store: &[u64], i: usize) -> u64 {
-    T16::from_u64s(&mut columnar::bytes::indexed::decode_u64s(store)).1.7[i]
 }
 
 // ================================================================
 // Complex types: do unused complex fields get eliminated?
 // ================================================================
 
-// Access field 0 (u64) when field 1 is a Result
 #[no_mangle] pub fn store_u64_result_f0(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], columnar::Results<&'a [u64], &'a [u64], &'a [u64], &'a [u64], &'a u64>);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
+    let ds = indexed::DecodedStore::new(store);
     *T::from_store(&ds, &mut 0).0.get(i).unwrap()
 }
 
-// Access field 0 (u64) when field 1 is a Vec<u64>
-#[no_mangle] pub fn store_u64_vec_f0(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], columnar::Vecs<&'a [u64], &'a [u64]>);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    *T::from_store(&ds, &mut 0).0.get(i).unwrap()
-}
-
-// Access field 0 (u64) when fields 1,2 are String and Vec<u32>
 #[no_mangle] pub fn store_u64_string_vec_f0(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], columnar::Strings<&'a [u64], &'a [u8]>, columnar::Vecs<&'a [u32], &'a [u64]>);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    let (a, _b, _c) = T::from_store(&ds, &mut 0);
-    a[i]
+    let ds = indexed::DecodedStore::new(store);
+    T::from_store(&ds, &mut 0).0[i]
 }
 
-// Access field 2 (Vec<u32>) skipping u64 and String
-#[no_mangle] pub fn store_u64_string_vec_flast(store: &[u64], i: usize) -> u32 {
-    type T<'a> = (&'a [u64], columnar::Strings<&'a [u64], &'a [u8]>, columnar::Vecs<&'a [u32], &'a [u64]>);
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    let (_a, _b, c) = T::from_store(&ds, &mut 0);
-    c.bounds[i] as u32
-}
-
-// Deeply nested: (u64, (u64, (u64, u64))) — access the innermost u64
 #[no_mangle] pub fn store_nested_inner(store: &[u64], i: usize) -> u64 {
     type T<'a> = (&'a [u64], (&'a [u64], (&'a [u64], &'a [u64])));
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
+    let ds = indexed::DecodedStore::new(store);
     T::from_store(&ds, &mut 0).1.1.1[i]
-}
-
-// Wide + deep: ((u64, u64, u64, u64), (u64, u64, u64, u64)) — access .1.3
-#[no_mangle] pub fn store_wide_deep(store: &[u64], i: usize) -> u64 {
-    type T<'a> = ((&'a [u64], &'a [u64], &'a [u64], &'a [u64]),
-                  (&'a [u64], &'a [u64], &'a [u64], &'a [u64]));
-    let ds = columnar::bytes::indexed::DecodedStore::new(store);
-    T::from_store(&ds, &mut 0).1.3[i]
-}
-
-// For comparison: same types via from_u64s (iterator)
-#[no_mangle] pub fn u64s_u64_string_vec_f0(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], columnar::Strings<&'a [u64], &'a [u8]>, columnar::Vecs<&'a [u32], &'a [u64]>);
-    let (a, _b, _c) = T::from_u64s(&mut columnar::bytes::indexed::decode_u64s(store));
-    a[i]
-}
-
-#[no_mangle] pub fn u64s_nested_inner(store: &[u64], i: usize) -> u64 {
-    type T<'a> = (&'a [u64], (&'a [u64], (&'a [u64], &'a [u64])));
-    T::from_u64s(&mut columnar::bytes::indexed::decode_u64s(store)).1.1.1[i]
 }
 
 fn main() {

--- a/examples/decode_bench.rs
+++ b/examples/decode_bench.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for Indexed::decode improvements.
+//! Benchmarks for indexed decode improvements.
 //!
 //! Measures decode + field access from encoded `[u64]` data,
 //! exercising both simple and complex types, and separating
@@ -21,7 +21,7 @@ fn bench_ns<F: FnMut()>(iters: u64, mut f: F) -> f64 {
     elapsed.as_nanos() as f64 / iters as f64
 }
 
-/// Encode a container into Indexed format, returning the `[u64]` store.
+/// Encode a container into indexed format, returning the `[u64]` store.
 fn encode_indexed<C: Borrow>(container: &C) -> Vec<u64>
 where
     for<'a> C::Borrowed<'a>: AsBytes<'a>,

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -25,8 +25,6 @@ impl<'a, T: AsBytes<'a>> AsBytes<'a> for Arc<T> {
 impl<'a, T: FromBytes<'a>> FromBytes<'a> for Arc<T> {
     const SLICE_COUNT: usize = T::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Arc::new(T::from_bytes(bytes)) }
-    #[inline(always)] fn from_byte_slices(bytes: &[&'a [u8]]) -> Self { Arc::new(T::from_byte_slices(bytes)) }
-    #[inline(always)] fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self { Arc::new(T::from_u64s(words)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Arc::new(T::from_store(store, offset)) }
 }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -61,8 +61,6 @@ impl<'a, C: AsBytes<'a>> AsBytes<'a> for Boxed<C> {
 impl<'a, C: FromBytes<'a>> FromBytes<'a> for Boxed<C> {
     const SLICE_COUNT: usize = C::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Self(C::from_bytes(bytes)) }
-    #[inline(always)] fn from_byte_slices(bytes: &[&'a [u8]]) -> Self { Self(C::from_byte_slices(bytes)) }
-    #[inline(always)] fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self { Self(C::from_u64s(words)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Self(C::from_store(store, offset)) }
 }
 impl<C: Index> Index for Boxed<C> {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -122,32 +122,8 @@ pub mod indexed {
         })
     }
 
-    /// Decodes an encoded sequence as `u64`-aligned word slices with trailing byte counts.
-    ///
-    /// Each item is `(&[u64], u8)` where the `u8` indicates how many bytes in the last
-    /// word are valid (0 means all 8 are valid, or the slice is empty).
-    /// This preserves alignment information from the original `&[u64]` store, avoiding
-    /// the need for alignment checks when casting back to typed slices.
-    #[inline(always)]
-    pub fn decode_u64s(store: &[u64]) -> impl Iterator<Item=(&[u64], u8)> {
-        let slices = store[0] as usize / 8 - 1;
-        let index = &store[..slices + 1];
-        let last = index[slices] as usize;
-        let last_w = (last + 7) / 8;
-        let words = &store[..last_w];
-        (0 .. slices).map(move |i| {
-            // Non-panicking index access: returns 0 for out-of-bounds,
-            // which .min(last) will clamp to produce an empty slice.
-            let upper = (*index.get(i + 1).unwrap_or(&0) as usize).min(last);
-            let lower = (((*index.get(i).unwrap_or(&0) as usize) + 7) & !7).min(upper);
-            let upper_w = ((upper + 7) / 8).min(words.len());
-            let lower_w = (lower / 8).min(upper_w);
-            let tail = (upper % 8) as u8;
-            (&words[lower_w..upper_w], tail)
-        })
-    }
 
-    /// A zero-allocation view into Indexed-encoded data, providing random access to individual slices.
+    /// A zero-allocation view into indexed-encoded data, providing random access to individual slices.
     ///
     /// Constructed from `&[u64]` in O(1), this wraps the offset index and data region
     /// and provides `get(k)` to retrieve the k-th slice as `(&[u64], u8)`.
@@ -163,7 +139,7 @@ pub mod indexed {
     }
 
     impl<'a> DecodedStore<'a> {
-        /// Creates a decoded view of an Indexed-encoded `&[u64]` store.
+        /// Creates a decoded view of an indexed-encoded `&[u64]` store.
         ///
         /// This is O(1) — it just reads the first offset to locate the index
         /// and data regions. No allocation, no iteration.
@@ -198,7 +174,7 @@ pub mod indexed {
         }
     }
 
-    /// Validates the internal structure of Indexed-encoded data.
+    /// Validates the internal structure of indexed-encoded data.
     ///
     /// Checks that offsets are well-formed, in bounds, and that the slice count matches
     /// `expected_slices`. This is a building block for [`validate`]; prefer calling
@@ -240,20 +216,22 @@ pub mod indexed {
     /// type-level compatibility (each slice's byte length is a multiple of its element
     /// size). Call this once at trust boundaries when receiving encoded data.
     ///
-    /// The `from_u64s` decode path performs no further validation at access time:
+    /// The `from_store` decode path performs no further validation at access time:
     /// it will not panic on malformed data, but may return incorrect results.
     /// There is no undefined behavior in any case. Call this method once before
-    /// using `from_u64s` to ensure the data is well-formed.
+    /// using `from_store` to ensure the data is well-formed.
     ///
     /// ```ignore
     /// type B<'a> = <MyContainer as Borrow>::Borrowed<'a>;
     /// indexed::validate::<B>(&store)?;
     /// // Now safe to use the non-panicking path:
-    /// let borrowed = B::from_u64s(&mut indexed::decode_u64s(&store));
+    /// let ds = indexed::DecodedStore::new(&store);
+    /// let borrowed = B::from_store(&ds, &mut 0);
     /// ```
     pub fn validate<'a, T: crate::FromBytes<'a>>(store: &[u64]) -> Result<(), String> {
         validate_structure(store, T::SLICE_COUNT)?;
-        let slices: Vec<_> = decode_u64s(store).collect();
+        let ds = DecodedStore::new(store);
+        let slices: Vec<_> = (0..ds.len()).map(|i| ds.get(i)).collect();
         T::validate(&slices)
     }
 
@@ -385,7 +363,7 @@ pub mod stash {
                 },
             }
         }
-        /// The number of bytes needed to write the contents using the `Indexed` encoder.
+        /// The number of bytes needed to write the contents using the [`indexed`] encoder.
         pub fn length_in_bytes(&self) -> usize {
             match self {
                 // We'll need one u64 for the length, then the length rounded up to a multiple of 8.
@@ -394,7 +372,7 @@ pub mod stash {
                 Stash::Align(a) => 8 * a.len(),
             }
         }
-        /// Write the contents into a `std::io::Write` using the `Indexed` encoder.
+        /// Write the contents into a `std::io::Write` using the [`indexed`] encoder.
         pub fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
             match self {
                 Stash::Typed(t) => { crate::bytes::indexed::write(writer, &t.borrow()).unwrap() },
@@ -476,29 +454,33 @@ mod test {
             assert_eq!(column3.get(2*i+1), column2.get(2*i+1));
         }
 
-        // Test from_byte_slices round-trip.
-        let byte_vec: Vec<&[u8]> = column.borrow().as_bytes().map(|(_, bytes)| bytes).collect();
-        let column4 = crate::Results::<&[u64], &[u64], &[u64], &[u64], &u64>::from_byte_slices(&byte_vec);
+        // Test from_store round-trip.
+        let mut store = Vec::new();
+        crate::bytes::indexed::encode(&mut store, &column.borrow());
+        let ds = crate::bytes::indexed::DecodedStore::new(&store);
+        let column4 = crate::Results::<&[u64], &[u64], &[u64], &[u64], &u64>::from_store(&ds, &mut 0);
         for i in 0..100 {
             assert_eq!(column.get(2*i+0), column4.get(2*i+0).copied().map_err(|e| *e));
             assert_eq!(column.get(2*i+1), column4.get(2*i+1).copied().map_err(|e| *e));
         }
     }
 
-    /// Test from_byte_slices for tuples.
+    /// Test from_store for tuples.
     #[test]
-    fn from_byte_slices_tuple() {
+    fn from_store_tuple() {
         use crate::common::{Push, Index};
-        use crate::{Borrow, AsBytes, FromBytes, ContainerOf};
+        use crate::{Borrow, FromBytes, ContainerOf};
 
         let mut column: ContainerOf<(u64, String, Vec<u32>)> = Default::default();
         for i in 0..50u64 {
             column.push(&(i, format!("hello {i}"), vec![i as u32; i as usize]));
         }
 
-        let byte_vec: Vec<&[u8]> = column.borrow().as_bytes().map(|(_, bytes)| bytes).collect();
+        let mut store = Vec::new();
+        crate::bytes::indexed::encode(&mut store, &column.borrow());
+        let ds = crate::bytes::indexed::DecodedStore::new(&store);
         type Borrowed<'a> = <ContainerOf<(u64, String, Vec<u32>)> as crate::Borrow>::Borrowed<'a>;
-        let reconstructed = Borrowed::from_byte_slices(&byte_vec);
+        let reconstructed = Borrowed::from_store(&ds, &mut 0);
         for i in 0..50 {
             let (a, b, _c) = reconstructed.get(i);
             assert_eq!(*a, i as u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,16 +622,14 @@ pub mod common {
     /// # Overriding methods
     ///
     /// The only required method is [`from_bytes`](Self::from_bytes). However, the default
-    /// implementations of [`from_u64s`](Self::from_u64s), [`from_store`](Self::from_store),
-    /// and [`element_sizes`](Self::element_sizes) fall back through `from_bytes`, which
-    /// contains panicking operations that prevent LLVM from eliminating unused fields.
-    /// Implementors should override all four methods to ensure optimal codegen.
-    /// Missing overrides are functionally correct but silently degrade performance.
+    /// implementation of [`from_store`](Self::from_store) falls back through `from_bytes`,
+    /// which contains panicking operations that prevent LLVM from eliminating unused fields.
+    /// Implementors should override `from_store` and [`element_sizes`](Self::element_sizes)
+    /// to ensure optimal codegen. Missing overrides are functionally correct but silently
+    /// degrade performance. The `#[derive(Columnar)]` macro generates all overrides
+    /// automatically.
     pub trait FromBytes<'a> {
         /// The number of byte slices this type consumes when reconstructed.
-        ///
-        /// This enables `from_byte_slices`, which can index directly into a slice
-        /// of byte slices rather than consuming from an iterator sequentially.
         const SLICE_COUNT: usize;
         /// Reconstructs `self` from a sequence of correctly aligned and sized bytes slices.
         ///
@@ -645,29 +643,6 @@ pub mod common {
         /// they are inlined. A single non-inlined function on a tree of `from_bytes` calls
         /// can cause the performance to drop significantly.
         fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self;
-        /// Reconstructs `self` from a slice of byte slices, using direct indexing.
-        ///
-        /// The slice should contain exactly `Self::SLICE_COUNT` elements.
-        /// This avoids the iterator chain overhead of `from_bytes`.
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self where Self: Sized {
-            Self::from_bytes(&mut bytes.iter().copied())
-        }
-        /// Reconstructs `self` from `u64`-aligned word slices with trailing byte counts.
-        ///
-        /// Each pair `(&[u64], u8)` provides a word slice and the number of valid bytes
-        /// in the last word (0 means all 8 bytes are valid, or the slice is empty).
-        /// Since all columnar data originates from `&[u64]` storage, this avoids the
-        /// alignment checks that `from_bytes` must perform when casting `&[u8]` back to
-        /// typed slices.
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self where Self: Sized {
-            Self::from_bytes(&mut words.map(|(w, tail)| {
-                let bytes: &[u8] = bytemuck::cast_slice(w);
-                let len = if tail == 0 { bytes.len() } else { bytes.len() - (8 - tail as usize) };
-                &bytes[..len]
-            }))
-        }
         /// Reconstructs `self` from a [`DecodedStore`](crate::bytes::indexed::DecodedStore),
         /// using direct random access at a given offset.
         ///
@@ -676,10 +651,15 @@ pub mod common {
         /// eliminate unused fields.
         #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self where Self: Sized {
-            // Default: delegate to from_u64s via an iterator over the store.
+            // Default: decode each slice from the store and delegate to from_bytes.
             let start = *offset;
             *offset += Self::SLICE_COUNT;
-            Self::from_u64s(&mut (start..*offset).map(|i| store.get(i)))
+            Self::from_bytes(&mut (start..*offset).map(|i| {
+                let (w, tail) = store.get(i);
+                let bytes: &[u8] = bytemuck::cast_slice(w);
+                let len = if tail == 0 { bytes.len() } else { bytes.len() - (8 - tail as usize) };
+                &bytes[..len]
+            }))
         }
         /// Reports the element sizes (in bytes) for each slice this type consumes.
         ///
@@ -693,7 +673,7 @@ pub mod common {
         }
         /// Validates that the given slices are compatible with this type.
         ///
-        /// The input matches the shape of `from_u64s`: each `(&[u64], u8)` is a word slice
+        /// The input provides `(&[u64], u8)` pairs: each is a word slice
         /// and trailing byte count. This type consumes `Self::SLICE_COUNT` entries and checks
         /// that each slice's byte length is a multiple of its element size.
         ///

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -28,19 +28,6 @@ macro_rules! implement_columnable {
                 bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()
             }
             #[inline(always)]
-            fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-                bytemuck::try_cast_slice(bytes[0]).unwrap()
-            }
-            #[inline(always)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-                let (w, tail) = words.next().unwrap_or((&[], 0));
-                // Cast directly from &[u64] to &[$index_type]. Always succeeds since
-                // u64 alignment (8) >= alignment of any primitive type.
-                let all: &[$index_type] = bytemuck::cast_slice(w);
-                let trim = ((8 - tail as usize) % 8) / std::mem::size_of::<$index_type>();
-                all.get(..all.len().wrapping_sub(trim)).unwrap_or(&[])
-            }
-            #[inline(always)]
             fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
                 let (w, tail) = store.get(*offset);
                 *offset += 1;
@@ -64,17 +51,6 @@ macro_rules! implement_columnable {
             fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self {
                 // We use `unwrap()` here in order to panic with the `bytemuck` error, which may be informative.
                 bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()
-            }
-            #[inline(always)]
-            fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-                bytemuck::try_cast_slice(bytes[0]).unwrap()
-            }
-            #[inline(always)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-                let (w, tail) = words.next().unwrap_or((&[], 0));
-                let all: &[[$index_type; N]] = bytemuck::cast_slice(w);
-                let trim = ((8 - tail as usize) % 8) / (std::mem::size_of::<$index_type>() * N);
-                all.get(..all.len().wrapping_sub(trim)).unwrap_or(&[])
             }
             #[inline(always)]
             fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
@@ -180,14 +156,6 @@ mod sizes {
             Self { values: CV::from_bytes(bytes) }
         }
         #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self { values: CV::from_byte_slices(bytes) }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self { values: CV::from_u64s(words) }
-        }
-        #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
@@ -268,14 +236,6 @@ mod sizes {
         #[inline(always)]
         fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self {
             Self { values: CV::from_bytes(bytes) }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self { values: CV::from_byte_slices(bytes) }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self { values: CV::from_u64s(words) }
         }
         #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
@@ -365,14 +325,6 @@ mod chars {
             Self { values: CV::from_bytes(bytes) }
         }
         #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self { values: CV::from_byte_slices(bytes) }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self { values: CV::from_u64s(words) }
-        }
-        #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
@@ -460,14 +412,6 @@ mod larges {
             Self { values: CV::from_bytes(bytes) }
         }
         #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self { values: CV::from_byte_slices(bytes) }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self { values: CV::from_u64s(words) }
-        }
-        #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
@@ -543,14 +487,6 @@ mod larges {
         #[inline(always)]
         fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self {
             Self { values: CV::from_bytes(bytes) }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self { values: CV::from_byte_slices(bytes) }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self { values: CV::from_u64s(words) }
         }
         #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
@@ -653,15 +589,6 @@ pub mod offsets {
                 Self { count: &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0] }
             }
             #[inline(always)]
-            fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-                Self { count: &bytemuck::try_cast_slice(bytes[0]).unwrap()[0] }
-            }
-            #[inline(always)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-                let (w, _) = words.next().unwrap_or((&[], 0));
-                Self { count: w.first().unwrap_or(&0) }
-            }
-            #[inline(always)]
             fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
                 let (w, _) = store.get(*offset); *offset += 1;
                 Self { count: w.first().unwrap_or(&0) }
@@ -756,22 +683,6 @@ pub mod offsets {
                 let stride = &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0];
                 let length = &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0];
                 let bounds = BC::from_bytes(bytes);
-                Self { stride, length, bounds }
-            }
-            #[inline(always)]
-            fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-                let stride = &bytemuck::try_cast_slice(bytes[0]).unwrap()[0];
-                let length = &bytemuck::try_cast_slice(bytes[1]).unwrap()[0];
-                let bounds = BC::from_byte_slices(&bytes[2..]);
-                Self { stride, length, bounds }
-            }
-            #[inline(always)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-                let (w1, _) = words.next().unwrap_or((&[], 0));
-                let stride = w1.first().unwrap_or(&0);
-                let (w2, _) = words.next().unwrap_or((&[], 0));
-                let length = w2.first().unwrap_or(&0);
-                let bounds = BC::from_u64s(words);
                 Self { stride, length, bounds }
             }
             #[inline(always)]
@@ -969,15 +880,6 @@ mod empty {
             Self { count: &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0], empty: () }
         }
         #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self { count: &bytemuck::try_cast_slice(bytes[0]).unwrap()[0], empty: () }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            let (w, _) = words.next().unwrap_or((&[], 0));
-            Self { count: w.first().unwrap_or(&0), empty: () }
-        }
-        #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             let (w, _) = store.get(*offset); *offset += 1;
             Self { count: w.first().unwrap_or(&0), empty: () }
@@ -1057,22 +959,6 @@ mod boolean {
             let values = crate::FromBytes::from_bytes(bytes);
             let last_word = &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0];
             let last_bits = &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0];
-            Self { values, last_word, last_bits }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            let values = VC::from_byte_slices(&bytes[..VC::SLICE_COUNT]);
-            let last_word = &bytemuck::try_cast_slice(bytes[VC::SLICE_COUNT]).unwrap()[0];
-            let last_bits = &bytemuck::try_cast_slice(bytes[VC::SLICE_COUNT + 1]).unwrap()[0];
-            Self { values, last_word, last_bits }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            let values = VC::from_u64s(words);
-            let (w1, _) = words.next().unwrap_or((&[], 0));
-            let last_word = w1.first().unwrap_or(&0);
-            let (w2, _) = words.next().unwrap_or((&[], 0));
-            let last_bits = w2.first().unwrap_or(&0);
             Self { values, last_word, last_bits }
         }
         #[inline(always)]
@@ -1217,20 +1103,6 @@ mod duration {
             Self {
                 seconds: crate::FromBytes::from_bytes(bytes),
                 nanoseconds: crate::FromBytes::from_bytes(bytes),
-            }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self {
-                seconds: SC::from_byte_slices(&bytes[..SC::SLICE_COUNT]),
-                nanoseconds: NC::from_byte_slices(&bytes[SC::SLICE_COUNT..]),
-            }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self {
-                seconds: SC::from_u64s(words),
-                nanoseconds: NC::from_u64s(words),
             }
         }
         #[inline(always)]

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -25,8 +25,6 @@ impl<'a, T: AsBytes<'a>> AsBytes<'a> for Rc<T> {
 impl<'a, T: FromBytes<'a>> FromBytes<'a> for Rc<T> {
     const SLICE_COUNT: usize = T::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Rc::new(T::from_bytes(bytes)) }
-    #[inline(always)] fn from_byte_slices(bytes: &[&'a [u8]]) -> Self { Rc::new(T::from_byte_slices(bytes)) }
-    #[inline(always)] fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self { Rc::new(T::from_u64s(words)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Rc::new(T::from_store(store, offset)) }
 }
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -103,20 +103,6 @@ impl<'a, BC: crate::FromBytes<'a>, VC: crate::FromBytes<'a>> crate::FromBytes<'a
         }
     }
     #[inline(always)]
-    fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-        Self {
-            bounds: BC::from_byte_slices(&bytes[..BC::SLICE_COUNT]),
-            values: VC::from_byte_slices(&bytes[BC::SLICE_COUNT..]),
-        }
-    }
-    #[inline(always)]
-    fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-        Self {
-            bounds: BC::from_u64s(words),
-            values: VC::from_u64s(words),
-        }
-    }
-    #[inline(always)]
     fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
         Self {
             bounds: BC::from_store(store, offset),

--- a/src/sums.rs
+++ b/src/sums.rs
@@ -63,20 +63,6 @@ pub mod rank_select {
             }
         }
         #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            Self {
-                counts: CC::from_byte_slices(&bytes[..CC::SLICE_COUNT]),
-                values: <crate::primitive::Bools<VC, &'a u64>>::from_byte_slices(&bytes[CC::SLICE_COUNT..]),
-            }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self {
-                counts: CC::from_u64s(words),
-                values: <crate::primitive::Bools<VC, &'a u64>>::from_u64s(words),
-            }
-        }
-        #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self {
                 counts: CC::from_store(store, offset),
@@ -284,23 +270,6 @@ pub mod result {
                 indexes: crate::FromBytes::from_bytes(bytes),
                 oks: crate::FromBytes::from_bytes(bytes),
                 errs: crate::FromBytes::from_bytes(bytes),
-            }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            let ix_count = <RankSelect<CC, VC, &'a u64>>::SLICE_COUNT;
-            Self {
-                indexes: crate::FromBytes::from_byte_slices(&bytes[..ix_count]),
-                oks: SC::from_byte_slices(&bytes[ix_count .. ix_count + SC::SLICE_COUNT]),
-                errs: TC::from_byte_slices(&bytes[ix_count + SC::SLICE_COUNT ..]),
-            }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self {
-                indexes: crate::FromBytes::from_u64s(words),
-                oks: SC::from_u64s(words),
-                errs: TC::from_u64s(words),
             }
         }
         #[inline(always)]
@@ -563,21 +532,6 @@ pub mod option {
             Self {
                 indexes: crate::FromBytes::from_bytes(bytes),
                 somes: crate::FromBytes::from_bytes(bytes),
-            }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            let ix_count = <RankSelect<CC, VC, &'a u64>>::SLICE_COUNT;
-            Self {
-                indexes: crate::FromBytes::from_byte_slices(&bytes[..ix_count]),
-                somes: TC::from_byte_slices(&bytes[ix_count..]),
-            }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            Self {
-                indexes: crate::FromBytes::from_u64s(words),
-                somes: TC::from_u64s(words),
             }
         }
         #[inline(always)]
@@ -894,24 +848,6 @@ pub mod discriminant {
             let count = &bytemuck::try_cast_slice(bytes.next().expect("Iterator exhausted prematurely")).unwrap()[0];
             let variant = crate::FromBytes::from_bytes(bytes);
             let offset = crate::FromBytes::from_bytes(bytes);
-            Self { tag, count, variant, offset }
-        }
-        #[inline(always)]
-        fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-            let tag = &bytemuck::try_cast_slice(bytes[0]).unwrap()[0];
-            let count = &bytemuck::try_cast_slice(bytes[1]).unwrap()[0];
-            let variant = <&'a [u8]>::from_byte_slices(&bytes[2..2 + <&'a [u8]>::SLICE_COUNT]);
-            let offset = <&'a [u64]>::from_byte_slices(&bytes[2 + <&'a [u8]>::SLICE_COUNT..]);
-            Self { tag, count, variant, offset }
-        }
-        #[inline(always)]
-        fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-            let (w_tag, _) = words.next().unwrap_or((&[], 0));
-            let tag = w_tag.first().unwrap_or(&0);
-            let (w_count, _) = words.next().unwrap_or((&[], 0));
-            let count = w_count.first().unwrap_or(&0);
-            let variant = crate::FromBytes::from_u64s(words);
-            let offset = crate::FromBytes::from_u64s(words);
             Self { tag, count, variant, offset }
         }
         #[inline(always)]

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -75,22 +75,6 @@ macro_rules! tuple_impl {
             }
             #[inline(always)]
             #[allow(non_snake_case)]
-            fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-                let mut _offset = 0;
-                $(
-                    let $name = $name::from_byte_slices(&bytes[_offset .. _offset + $name::SLICE_COUNT]);
-                    _offset += $name::SLICE_COUNT;
-                )*
-                ($($name,)*)
-            }
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-                $(let $name = $name::from_u64s(words);)*
-                ($($name,)*)
-            }
-            #[inline(always)]
-            #[allow(non_snake_case)]
             fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
                 $(let $name = $name::from_store(store, offset);)*
                 ($($name,)*)

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -134,20 +134,6 @@ impl<'a, TC: crate::FromBytes<'a>, BC: crate::FromBytes<'a>> crate::FromBytes<'a
         }
     }
     #[inline(always)]
-    fn from_byte_slices(bytes: &[&'a [u8]]) -> Self {
-        Self {
-            bounds: BC::from_byte_slices(&bytes[..BC::SLICE_COUNT]),
-            values: TC::from_byte_slices(&bytes[BC::SLICE_COUNT..]),
-        }
-    }
-    #[inline(always)]
-    fn from_u64s(words: &mut impl Iterator<Item=(&'a [u64], u8)>) -> Self {
-        Self {
-            bounds: BC::from_u64s(words),
-            values: TC::from_u64s(words),
-        }
-    }
-    #[inline(always)]
     fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
         Self {
             bounds: BC::from_store(store, offset),


### PR DESCRIPTION
Written with Claude, this adds a structured form of decoding that does not use iteration, as this proves to be hard to fully elide when not used. The type `DecodedStore` essentially provides random access to slices, and could be generalized in the future with a trait that does something like this (not `std::ops::Index`, because the lifetimes would be too short).

Claude says:

```
  Summary

  Introduces DecodedStore, a zero-allocation view into indexed-encoded &[u64]
   data that provides O(1) random access to individual slices. The new
  FromBytes::from_store method uses it to give each field independent access
  at its compile-time-known offset, replacing the iterator-based from_u64s
  path.

  The key difference from the iterator approach: each field's access is
  independent — no sequential dependency, no iterator state to advance. This
  lets LLVM fully eliminate unused fields when only one field of a tuple is
  accessed.

  Assembly: critical-path instructions to access one field

  Accessing field 0 of a k-tuple of u64 columns, from raw &[u64] to returned
  value:

  ┌─────────────┬────────────────────────┬──────────────────────┐
  │ Tuple width │  from_bytes (before)   │  from_store (after)  │
  ├─────────────┼────────────────────────┼──────────────────────┤
  │ k=3         │ 133 insns, 14 branches │ 49 insns, 3 branches │
  ├─────────────┼────────────────────────┼──────────────────────┤
  │ k=8         │ 273 insns, 29 branches │ 49 insns, 3 branches │
  ├─────────────┼────────────────────────┼──────────────────────┤
  │ k=16        │ 545 insns, 56 branches │ 49 insns, 3 branches │
  └─────────────┴────────────────────────┴──────────────────────┘

  Constant in k, constant in field position (49 for field 0, 54 for any other
   field). LLVM eliminates unused fields across all type combinators —
  tuples, Results, Options, Vecs, Strings, and arbitrary nesting.

  ┌────────────────────────┬───────────────────┬────────────┬────────────┐
  │          Type          │     Accessing     │ from_bytes │ from_store │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤   
  │ (u64, u64, u64)        │ f0                │ 133 / 14   │ 49 / 3     │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤   
  │ (u64 x8)               │ f0                │ 273 / 29   │ 49 / 3     │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤
  │ (u64 x16)              │ f0                │ 545 / 56   │ 49 / 3     │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤
  │ (u64, Result<u64,u64>) │ f0, skip Result   │ 132 / 11   │ 49 / 3     │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤
  │ (u64, String, Vec)     │ f0, skip          │ 133 / 14   │ 49 / 3     │
  │                        │ String+Vec        │            │            │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤
  │ (u64, (u64, (u64,      │ innermost field   │ 133 / 14   │ 54 / 4     │
  │ u64)))                 │                   │            │            │
  ├────────────────────────┼───────────────────┼────────────┼────────────┤
  │ ((u64 x4), (u64 x4))   │ .1.3              │ 273 / 29   │ 54 / 4     │
  └────────────────────────┴───────────────────┴────────────┴────────────┘

  (Format: critical-path instructions / branches. The from_bytes column does
  not have a k=16 Result measurement but would be proportionally larger.)


  Changes

  - DecodedStore: two-field struct (index and words), constructed in O(1),
  provides .get(k) -> (&[u64], u8) with non-panicking random access
  - FromBytes::from_store: new method with overrides for all types in the
  library, used by Stash::borrow
  - Removes from_u64s, decode_u64s, and from_byte_slices (all superseded)
  - Adds from_store to the derive macro for structs and enums
```