### PR TITLE
Make element_sizes return Result, default to Err

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,11 +665,11 @@ pub mod common {
         ///
         /// Implementors should override this to report their actual element sizes.
         /// For example, `&[u32]` pushes `4`, while a tuple delegates to each field.
-        /// The default implementation pushes `1` for each slice (accepting any byte length).
-        fn element_sizes(sizes: &mut Vec<usize>) {
-            for _ in 0..Self::SLICE_COUNT {
-                sizes.push(1);
-            }
+        /// The default returns `Err`, so that [`validate`](Self::validate) rejects
+        /// data for types that have not implemented this method.
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            let _ = sizes;
+            Err(format!("element_sizes not implemented for this type (SLICE_COUNT = {})", Self::SLICE_COUNT))
         }
         /// Validates that the given slices are compatible with this type.
         ///
@@ -683,7 +683,7 @@ pub mod common {
                 return Err(format!("expected {} slices but got {}", Self::SLICE_COUNT, slices.len()));
             }
             let mut sizes = Vec::new();
-            Self::element_sizes(&mut sizes);
+            Self::element_sizes(&mut sizes)?;
             for (i, elem_size) in sizes.iter().enumerate() {
                 let (words, tail) = &slices[i];
                 let byte_len = words.len() * 8 - ((8 - *tail as usize) % 8);

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -35,8 +35,9 @@ macro_rules! implement_columnable {
                 let trim = ((8 - tail as usize) % 8) / std::mem::size_of::<$index_type>();
                 all.get(..all.len().wrapping_sub(trim)).unwrap_or(&[])
             }
-            fn element_sizes(sizes: &mut Vec<usize>) {
+            fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 sizes.push(std::mem::size_of::<$index_type>());
+                Ok(())
             }
         }
         impl<'a, const N: usize> crate::AsBytes<'a> for &'a [[$index_type; N]] {
@@ -60,8 +61,9 @@ macro_rules! implement_columnable {
                 let trim = ((8 - tail as usize) % 8) / (std::mem::size_of::<$index_type>() * N);
                 all.get(..all.len().wrapping_sub(trim)).unwrap_or(&[])
             }
-            fn element_sizes(sizes: &mut Vec<usize>) {
+            fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 sizes.push(std::mem::size_of::<$index_type>() * N);
+                Ok(())
             }
         }
     )* }

--- a/src/string.rs
+++ b/src/string.rs
@@ -109,9 +109,10 @@ impl<'a, BC: crate::FromBytes<'a>, VC: crate::FromBytes<'a>> crate::FromBytes<'a
             values: VC::from_store(store, offset),
         }
     }
-    fn element_sizes(sizes: &mut Vec<usize>) {
-        BC::element_sizes(sizes);
-        VC::element_sizes(sizes);
+    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+        BC::element_sizes(sizes)?;
+        VC::element_sizes(sizes)?;
+        Ok(())
     }
 }
 

--- a/src/sums.rs
+++ b/src/sums.rs
@@ -860,11 +860,12 @@ pub mod discriminant {
             let offset_field = crate::FromBytes::from_store(store, offset);
             Self { tag, count, variant, offset: offset_field }
         }
-        fn element_sizes(sizes: &mut Vec<usize>) {
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             sizes.push(8); // tag
             sizes.push(8); // count
-            <&[u8]>::element_sizes(sizes);
-            <&[u64]>::element_sizes(sizes);
+            <&[u8]>::element_sizes(sizes)?;
+            <&[u64]>::element_sizes(sizes)?;
+            Ok(())
         }
     }
 

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -79,8 +79,9 @@ macro_rules! tuple_impl {
                 $(let $name = $name::from_store(store, offset);)*
                 ($($name,)*)
             }
-            fn element_sizes(sizes: &mut Vec<usize>) {
-                $($name::element_sizes(sizes);)*
+            fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+                $($name::element_sizes(sizes)?;)*
+                Ok(())
             }
         }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -140,9 +140,10 @@ impl<'a, TC: crate::FromBytes<'a>, BC: crate::FromBytes<'a>> crate::FromBytes<'a
             values: TC::from_store(store, offset),
         }
     }
-    fn element_sizes(sizes: &mut Vec<usize>) {
-        BC::element_sizes(sizes);
-        TC::element_sizes(sizes);
+    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+        BC::element_sizes(sizes)?;
+        TC::element_sizes(sizes)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The default element_sizes now returns Err("unimplemented") instead of silently accepting any byte length. This ensures that validate rejects data for types that haven't implemented element_sizes, rather than passing validation and producing garbage from from_store.

Types that override element_sizes push their sizes and return Ok(()). The derive macro already generates this automatically.