### PR TITLE
Introduce `BorrowedOf` type alias for ergonomics

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,5 +1,5 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use columnar::{Columnar, Container, Clear, FromBytes};
+use columnar::{Columnar, BorrowedOf, Borrow, Clear};
 use columnar::bytes::indexed;
 use serde::{Serialize, Deserialize};
 
@@ -70,8 +70,8 @@ fn goser_decode(b: &mut Bencher) {
     indexed::encode(&mut words, &container.borrow());
     b.bytes = 8 * words.len() as u64;
     b.iter(|| {
-        let mut slices = indexed::decode(&mut words);
-        let foo = <<Log as Columnar>::Container as Container>::Borrowed::from_bytes(&mut slices);
+        type B<'a> = BorrowedOf<'a, Log>;
+        let foo = indexed::decode::<B>(&words);
         bencher::black_box(foo);
     });
 }

--- a/examples/decode_bench.rs
+++ b/examples/decode_bench.rs
@@ -75,7 +75,7 @@ fn exp2_vec_u8(n: usize, iters: u64) {
     // Decode + access
     let ns_decode_access = bench_ns(iters, || {
         let mut slices = Indexed::decode(&store);
-        type B<'a> = <ContainerOf<Vec<u8>> as Borrow>::Borrowed<'a>;
+        type B<'a> = BorrowedOf<'a, Vec<u8>>;
         let borrowed = B::from_bytes(&mut slices);
         black_box(borrowed.get(idx));
     });
@@ -83,7 +83,7 @@ fn exp2_vec_u8(n: usize, iters: u64) {
     // Access only
     let slices_vec: Vec<&[u8]> = Indexed::decode(&store).collect();
     let mut slices_iter = slices_vec.iter().copied();
-    type B2<'a> = <ContainerOf<Vec<u8>> as Borrow>::Borrowed<'a>;
+    type B2<'a> = BorrowedOf<'a, Vec<u8>>;
     let borrowed_once = B2::from_bytes(&mut slices_iter);
     let ns_access_only = bench_ns(iters, || {
         black_box(borrowed_once.get(idx));
@@ -155,7 +155,7 @@ fn exp4_tuple1(n: usize, iters: u64) {
 
     let ns = bench_ns(iters, || {
         let mut slices = Indexed::decode(&store);
-        type B<'a> = <ContainerOf<(u64,)> as Borrow>::Borrowed<'a>;
+        type B<'a> = BorrowedOf<'a, (u64,)>;
         let b = B::from_bytes(&mut slices);
         black_box(b.get(idx));
     });
@@ -170,7 +170,7 @@ fn exp4_tuple2(n: usize, iters: u64) {
 
     let ns = bench_ns(iters, || {
         let mut slices = Indexed::decode(&store);
-        type B<'a> = <ContainerOf<(u64, u64)> as Borrow>::Borrowed<'a>;
+        type B<'a> = BorrowedOf<'a, (u64, u64)>;
         let b = B::from_bytes(&mut slices);
         let (_a, b_val) = b.get(idx);
         black_box(b_val);
@@ -186,7 +186,7 @@ fn exp4_tuple3(n: usize, iters: u64) {
 
     let ns = bench_ns(iters, || {
         let mut slices = Indexed::decode(&store);
-        type B<'a> = <ContainerOf<(u64, u64, u64)> as Borrow>::Borrowed<'a>;
+        type B<'a> = BorrowedOf<'a, (u64, u64, u64)>;
         let b = B::from_bytes(&mut slices);
         let (_a, _b, c_val) = b.get(idx);
         black_box(c_val);
@@ -202,7 +202,7 @@ fn exp4_tuple5(n: usize, iters: u64) {
 
     let ns = bench_ns(iters, || {
         let mut slices = Indexed::decode(&store);
-        type B<'a> = <ContainerOf<(u64, u64, u64, u64, u64)> as Borrow>::Borrowed<'a>;
+        type B<'a> = BorrowedOf<'a, (u64, u64, u64, u64, u64)>;
         let b = B::from_bytes(&mut slices);
         let (_a, _b, _c, _d, e_val) = b.get(idx);
         black_box(e_val);
@@ -218,7 +218,7 @@ fn exp4_tuple8(n: usize, iters: u64) {
 
     let ns = bench_ns(iters, || {
         let mut slices = Indexed::decode(&store);
-        type B<'a> = <ContainerOf<(u64, u64, u64, u64, u64, u64, u64, u64)> as Borrow>::Borrowed<'a>;
+        type B<'a> = BorrowedOf<'a, (u64, u64, u64, u64, u64, u64, u64, u64)>;
         let b = B::from_bytes(&mut slices);
         let (_a, _b, _c, _d, _e, _f, _g, h_val) = b.get(idx);
         black_box(h_val);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -281,7 +281,7 @@ pub mod indexed {
             let mut store = Vec::new();
             encode(&mut store, &column.borrow());
 
-            type B<'a> = <ContainerOf<(u64, u64, u64)> as crate::Borrow>::Borrowed<'a>;
+            type B<'a> = crate::BorrowedOf<'a, (u64, u64, u64)>;
             assert!(super::validate::<B>(&store).is_ok());
 
             // Wrong slice count should fail structural validation.
@@ -299,7 +299,7 @@ pub mod indexed {
             let mut store = Vec::new();
             encode(&mut store, &column.borrow());
 
-            type B<'a> = <ContainerOf<(u64, String, Vec<u32>)> as crate::Borrow>::Borrowed<'a>;
+            type B<'a> = crate::BorrowedOf<'a, (u64, String, Vec<u32>)>;
             assert!(super::validate::<B>(&store).is_ok());
         }
     }
@@ -479,7 +479,7 @@ mod test {
         let mut store = Vec::new();
         crate::bytes::indexed::encode(&mut store, &column.borrow());
         let ds = crate::bytes::indexed::DecodedStore::new(&store);
-        type Borrowed<'a> = <ContainerOf<(u64, String, Vec<u32>)> as crate::Borrow>::Borrowed<'a>;
+        type Borrowed<'a> = crate::BorrowedOf<'a, (u64, String, Vec<u32>)>;
         let reconstructed = Borrowed::from_store(&ds, &mut 0);
         for i in 0..50 {
             let (a, b, _c) = reconstructed.get(i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,11 @@ pub trait Columnar : 'static {
 /// Equivalent to `<T as Columnar>::Container`.
 pub type ContainerOf<T> = <T as Columnar>::Container;
 
+/// The borrowed container type of columnar type `T`.
+///
+/// Equivalent to `<<T as Columnar>::Container> as Borrow>::Borrowed<'a>`.
+pub type BorrowedOf<'a, T> = <ContainerOf<T> as Borrow>::Borrowed<'a>;
+
 /// For a lifetime, the reference type of columnar type `T`.
 ///
 /// Equivalent to `<ContainerOf<T> as Borrow>::Ref<'a>`.


### PR DESCRIPTION
Introduces a `BorrowedOf` type alias akin to `ContainerOf`, which reduces a lot of visual noise when, among other things, attempting to decode data into an intended borrowed representation.