### PR TITLE
Change `Strings::Ref<'_>` from `&str` to `&[u8]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 /target
+/wip

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -484,7 +484,7 @@ mod test {
         for i in 0..50 {
             let (a, b, _c) = reconstructed.get(i);
             assert_eq!(*a, i as u64);
-            assert_eq!(b, &*format!("hello {i}"));
+            assert_eq!(b, format!("hello {i}").as_bytes());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,13 @@ fn main() {
     for (col, row) in columns.into_index_iter().zip(roster) {
         match (col, row) {
             (GroupReference::Solo(p0), Group::Solo(p1)) => {
-                assert_eq!(p0.0, p1.0);
+                assert_eq!(p0.0, p1.0.as_bytes());
                 assert_eq!(p0.1, &p1.1);
             },
             (GroupReference::Team(p0s), Group::Team(p1s)) => {
                 assert_eq!(p0s.len(), p1s.len());
                 for (p0, p1) in p0s.into_iter().zip(p1s) {
-                    assert_eq!(p0.0, p1.0);
+                    assert_eq!(p0.0, p1.0.as_bytes());
                     assert_eq!(p0.1, &p1.1);
                 }
             },

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,6 +1,10 @@
 use super::{Clear, Columnar, Container, Len, Index, IndexAs, Push, HeapSize, Borrow};
 
 /// A stand-in for `Vec<String>`.
+///
+/// The reference type for `Strings` is `&[u8]` rather than `&str` to remove utf8 validation
+/// from the critical path of reads. You get to make the call about whether and how you'd like
+/// to manage this validation. The `copy_from` and `into_owned` methods panic on invalid data.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Strings<BC = Vec<u64>, VC = Vec<u8>> {
@@ -14,10 +18,12 @@ impl Columnar for String {
     #[inline(always)]
     fn copy_from<'a>(&mut self, other: crate::Ref<'a, Self>) {
         self.clear();
-        self.push_str(other);
+        self.push_str(std::str::from_utf8(other).expect("invalid utf8 in Strings column"));
     }
     #[inline(always)]
-    fn into_owned<'a>(other: crate::Ref<'a, Self>) -> Self { other.to_string() }
+    fn into_owned<'a>(other: crate::Ref<'a, Self>) -> Self {
+        std::str::from_utf8(other).expect("invalid utf8 in Strings column").to_string()
+    }
     type Container = Strings;
 }
 
@@ -26,16 +32,18 @@ impl Columnar for Box<str> {
     fn copy_from<'a>(&mut self, other: crate::Ref<'a, Self>) {
         let mut s = String::from(std::mem::take(self));
         s.clear();
-        s.push_str(other);
+        s.push_str(std::str::from_utf8(other).expect("invalid utf8 in Strings column"));
         *self = s.into_boxed_str();
     }
     #[inline(always)]
-    fn into_owned<'a>(other: crate::Ref<'a, Self>) -> Self { Self::from(other) }
+    fn into_owned<'a>(other: crate::Ref<'a, Self>) -> Self {
+        Self::from(std::str::from_utf8(other).expect("invalid utf8 in Strings column"))
+    }
     type Container = Strings;
 }
 
 impl<BC: crate::common::BorrowIndexAs<u64>> Borrow for Strings<BC, Vec<u8>> {
-    type Ref<'a> = &'a str;
+    type Ref<'a> = &'a [u8];
     type Borrowed<'a> = Strings<BC::Borrowed<'a>, &'a [u8]> where BC: 'a;
     #[inline(always)]
     fn borrow<'a>(&'a self) -> Self::Borrowed<'a> {
@@ -121,23 +129,23 @@ impl<BC: Len, VC> Len for Strings<BC, VC> {
 }
 
 impl<'a, BC: Len+IndexAs<u64>> Index for Strings<BC, &'a [u8]> {
-    type Ref = &'a str;
+    type Ref = &'a [u8];
     #[inline(always)] fn get(&self, index: usize) -> Self::Ref {
         let lower = if index == 0 { 0 } else { self.bounds.index_as(index - 1) };
         let upper = self.bounds.index_as(index);
         let lower: usize = lower.try_into().expect("bounds must fit in `usize`");
         let upper: usize = upper.try_into().expect("bounds must fit in `usize`");
-        std::str::from_utf8(&self.values[lower .. upper]).expect("&[u8] must be valid utf8")
+        &self.values[lower .. upper]
     }
 }
 impl<'a, BC: Len+IndexAs<u64>> Index for &'a Strings<BC, Vec<u8>> {
-    type Ref = &'a str;
+    type Ref = &'a [u8];
     #[inline(always)] fn get(&self, index: usize) -> Self::Ref {
         let lower = if index == 0 { 0 } else { self.bounds.index_as(index - 1) };
         let upper = self.bounds.index_as(index);
         let lower: usize = lower.try_into().expect("bounds must fit in `usize`");
         let upper: usize = upper.try_into().expect("bounds must fit in `usize`");
-        std::str::from_utf8(&self.values[lower .. upper]).expect("&[u8] must be valid utf8")
+        &self.values[lower .. upper]
     }
 }
 
@@ -153,6 +161,12 @@ impl<'a, BC: Len+IndexAs<u64>> Index for &'a Strings<BC, Vec<u8>> {
 //     }
 // }
 
+impl<BC: for<'a> Push<&'a u64>> Push<&[u8]> for Strings<BC> {
+    #[inline(always)] fn push(&mut self, item: &[u8]) {
+        self.values.extend_from_slice(item);
+        self.bounds.push(&(self.values.len() as u64));
+    }
+}
 impl<BC: for<'a> Push<&'a u64>> Push<&String> for Strings<BC> {
     #[inline(always)] fn push(&mut self, item: &String) {
         self.values.extend_from_slice(item.as_bytes());

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -180,8 +180,8 @@ mod test {
         assert_eq!(column.heap_size(), (3590, 4608));
 
         for i in 0..100u64 {
-            assert_eq!((&column).get((2*i+0) as usize), (&i, &(i as u8), i.to_string().as_str()));
-            assert_eq!((&column).get((2*i+1) as usize), (&i, &(i as u8), ""));
+            assert_eq!((&column).get((2*i+0) as usize), (&i, &(i as u8), i.to_string().as_bytes()));
+            assert_eq!((&column).get((2*i+1) as usize), (&i, &(i as u8), &b""[..]));
         }
 
         // Compare to the heap size of a `Vec<Option<usize>>`.


### PR DESCRIPTION
The `&str` reference type of `Strings` validates the `&[u8]` data at index time, at some cost. Not only is it really quite expensive, the potential panic means it cannot be optimized away even if it is not examined. Users are able to do whatever they like with the `&[u8]`, including validating, unsafely casting, other things like this that are more appropriate for the user to decide than us.

```
⏺ Here are the before/after numbers:

  ---
  Index-only (n=10,000, hot cache)

  ┌───────────────────────┬───────────────┬───────────────┬─────────┐
  │       Benchmark       │ Before (&str) │ After (&[u8]) │ Speedup │
  ├───────────────────────┼───────────────┼───────────────┼─────────┤
  │ (String,u64,String).0 │ 18.9 ns       │ 1.1 ns        │ 17x     │
  ├───────────────────────┼───────────────┼───────────────┼─────────┤
  │ Option<String> match  │ 11.6 ns       │ 4.0 ns        │ 2.9x    │
  ├───────────────────────┼───────────────┼───────────────┼─────────┤
  │ 8-tuple .4 (String)   │ 9.4 ns        │ 0.9 ns        │ 10x     │
  └───────────────────────┴───────────────┴───────────────┴─────────┘

  Cache effects — random access at scale (ns/access, 100K accesses)

  ┌────────────┬─────────────────┬────────────────┬─────────────────┬────────────────┐
  │     n      │     Before      │     After      │     Before      │     After      │
  │            │   String/seq    │   String/seq   │   String/rnd    │   String/rnd   │
  ├────────────┼─────────────────┼────────────────┼─────────────────┼────────────────┤
  │ 1,000      │ 6.1             │ 0.9            │ 6.8             │ 0.9            │
  ├────────────┼─────────────────┼────────────────┼─────────────────┼────────────────┤
  │ 10,000     │ 6.0             │ 0.9            │ 13.1            │ 0.9            │
  ├────────────┼─────────────────┼────────────────┼─────────────────┼────────────────┤
  │ 100,000    │ 6.1             │ 0.9            │ 14.1            │ 0.9            │
  ├────────────┼─────────────────┼────────────────┼─────────────────┼────────────────┤
  │ 1,000,000  │ 6.1             │ 1.1            │ 18.8            │ 5.6            │
  ├────────────┼─────────────────┼────────────────┼─────────────────┼────────────────┤
  │ 10,000,000 │ 6.1             │ 0.9            │ 76.4            │ 5.9            │
  └────────────┴─────────────────┴────────────────┴─────────────────┴────────────────┘

  ┌────────────┬─────────────────┬─────────────────┬─────────────────┬─────────────────┐
  │     n      │     Before      │     After       │     Before      │     After       │
  │            │  Opt<Str>/seq   │  Opt<Str>/seq   │  Opt<Str>/rnd   │  Opt<Str>/rnd   │
  ├────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┤
  │ 1,000      │ 7.2             │ 3.6             │ 19.1            │ 10.7            │
  ├────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┤
  │ 10,000     │ 7.7             │ 3.7             │ 23.3            │ 10.5            │
  ├────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┤
  │ 100,000    │ 8.0             │ 3.8             │ 25.0            │ 10.3            │
  ├────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┤
  │ 1,000,000  │ 7.9             │ 3.8             │ 29.1            │ 10.9            │
  ├────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┤
  │ 10,000,000 │ 8.0             │ 3.7             │ 48.3            │ 12.2            │
  └────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘

  The headline number: random String access at 10M elements drops from 76.4 ns to 5.9 ns —
  a 13x improvement. The from_utf8 validation was not only expensive in itself, it
  amplified cache misses by forcing a read of every byte in the string.
```