### PR TITLE
Remove `HeapSize` trait

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,6 +1,6 @@
 use serde_json::Value as JsonJson;
 
-use columnar::{Push, Len, Index, HeapSize};
+use columnar::{Push, Len, Index};
 use columnar::{Vecs, Strings, Lookbacks};
 
 /// Stand in for JSON, from `serde_json`.
@@ -14,18 +14,7 @@ pub enum Json {
     Object(Vec<(String, Json)>),
 }
 
-impl HeapSize for Json {
-    fn heap_size(&self) -> (usize, usize) {
-        match self {
-            Json::Null => (0, 0),
-            Json::Bool(_) => (0, 0),
-            Json::Number(_) => (0, 0),
-            Json::String(s) => (0, s.len()),
-            Json::Array(a) => a.heap_size(),
-            Json::Object(o) => o.heap_size(),
-        }
-    }
-}
+
 
 impl Json {
     pub fn from_json(json: JsonJson) -> Self {
@@ -55,10 +44,6 @@ pub enum JsonIdx {
     Object(usize),
 }
 
-impl HeapSize for JsonIdx {
-    fn heap_size(&self) -> (usize, usize) { (0, 0) }
-}
-
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Number (serde_json::Number);
 
@@ -68,8 +53,6 @@ impl std::ops::Deref for Number {
         &self.0
     }
 }
-
-impl HeapSize for Number { }
 
 /// Stand-in for `Vec<Json>`.
 ///
@@ -101,17 +84,6 @@ pub struct Jsons {
     pub strings: Lookbacks<Strings>,
     pub arrays: Vecs<Vec<JsonIdx>>,
     pub objects: Vecs<(Lookbacks<Strings>, Vec<JsonIdx>)>,
-}
-
-impl HeapSize for Jsons {
-    fn heap_size(&self) -> (usize, usize) {
-        let (l0, c0) = self.roots.heap_size();
-        let (l1, c1) = self.numbers.heap_size();
-        let (l2, c2) = self.strings.heap_size();
-        let (l3, c3) = self.arrays.heap_size();
-        let (l4, c4) = self.objects.heap_size();
-        (l0 + l1 + l2 + l3 + l4, c0 + c1 + c2 + c3 + c4)
-    }
 }
 
 /// Stand-in for `&'a Json`.
@@ -294,7 +266,7 @@ impl<'a> JsonQueues<'a> {
 
 fn main() {
 
-    use columnar::{Push, Len, Index, HeapSize};
+    use columnar::{Push, Len, Index};
 
     use std::fs::File;
     use serde_json::Value as JsonValue;
@@ -312,21 +284,12 @@ fn main() {
     println!("{:?}\tjson_vals cloned", time);
 
     let values = records.clone().into_iter().map(Json::from_json).collect::<Vec<_>>();
-    println!("\t\tjson_vals heapsize: {:?}", values.heap_size().0);
 
     let timer = std::time::Instant::now();
     let mut json_cols = Jsons::default();
     json_cols.extend(values.iter());
     let time = timer.elapsed();
     println!("{:?}\tjson_cols formed", time);
-    println!("\t\tjson_cols heapsize: {:?}", json_cols.heap_size().0);
-    println!("\t\tjson_cols.roots:    {:?}", json_cols.roots.heap_size().0);
-    println!("\t\tjson_cols.numbers:  {:?}", json_cols.numbers.heap_size().0);
-    println!("\t\tjson_cols.strings:  {:?}", json_cols.strings.heap_size().0);
-    println!("\t\tjson_cols.arrays:   {:?}", json_cols.arrays.heap_size().0);
-    println!("\t\tjson_cols.objects:  {:?}", json_cols.objects.heap_size().0);
-    println!("\t\tjson_cols.objects.values.0:  {:?}", json_cols.objects.values.0.heap_size().0);
-    println!("\t\tjson_cols.objects.values.1:  {:?}", json_cols.objects.values.1.heap_size().0);
 
     println!("\t\tjson_cols.arrays.len: {:?}", json_cols.arrays.len());
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,7 +1,7 @@
 //! Implementations of traits for `Arc<T>`
 use std::sync::Arc;
 
-use crate::{Len, Borrow, HeapSize, AsBytes, FromBytes};
+use crate::{Len, Borrow, AsBytes, FromBytes};
 
 impl<T: Borrow> Borrow for Arc<T> {
     type Ref<'a> = T::Ref<'a> where T: 'a;
@@ -12,12 +12,6 @@ impl<T: Borrow> Borrow for Arc<T> {
 }
 impl<T: Len> Len for Arc<T> {
     #[inline(always)] fn len(&self) -> usize { self.as_ref().len() }
-}
-impl<T: HeapSize> HeapSize for Arc<T> {
-    fn heap_size(&self) -> (usize, usize) {
-        let (l, c) = self.as_ref().heap_size();
-        (l + std::mem::size_of::<Arc<T>>(), c + std::mem::size_of::<Arc<T>>())
-    }
 }
 impl<'a, T: AsBytes<'a>> AsBytes<'a> for Arc<T> {
     #[inline(always)] fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> { self.as_ref().as_bytes() }
@@ -31,7 +25,7 @@ impl<'a, T: FromBytes<'a>> FromBytes<'a> for Arc<T> {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use crate::{Borrow, Len, HeapSize, AsBytes, FromBytes};
+    use crate::{Borrow, Len, AsBytes, FromBytes};
 
     #[test]
     fn test_borrow() {
@@ -44,14 +38,6 @@ mod tests {
     fn test_len() {
         let x = Arc::new(vec![1, 2, 3]);
         assert_eq!(x.len(), 3);
-    }
-
-    #[test]
-    fn test_heap_size() {
-        let x = Arc::new(vec![1, 2, 3]);
-        let (l, c) = x.heap_size();
-        assert!(l > 0);
-        assert!(c > 0);
     }
 
     #[test]

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -6,7 +6,7 @@
 //! We need this wrapper to distinguish which [`Push`] implementation to use, otherwise
 //! the implementations would conflict.
 
-use crate::{AsBytes, Borrow, Clear, Columnar, Container, FromBytes, HeapSize, Index, IndexMut, Len, Push, Ref};
+use crate::{AsBytes, Borrow, Clear, Columnar, Container, FromBytes, Index, IndexMut, Len, Push, Ref};
 
 impl<T: Columnar> Columnar for Box<T> {
     type Container = Boxed<T::Container>;
@@ -71,6 +71,4 @@ impl<C: IndexMut> IndexMut for Boxed<C> {
     type IndexMut<'a> = Boxed<C::IndexMut<'a>> where Self: 'a;
     #[inline(always)] fn get_mut(&mut self, index: usize) -> Self::IndexMut<'_> { Boxed(self.0.get_mut(index)) }
 }
-impl<C: HeapSize> HeapSize for Boxed<C> {
-    #[inline(always)] fn heap_size(&self) -> (usize, usize) { self.0.heap_size() }
-}
+

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -387,7 +387,7 @@ pub mod stash {
         /// // Borrow and index into individual columns.
         /// let borrowed = stash.borrow();
         /// assert_eq!(*Index::get(&borrowed.0, 0), 0u64);
-        /// assert_eq!(borrowed.1.get(1), "world");
+        /// assert_eq!(borrowed.1.get(1), b"world");
         /// ```
         pub fn try_from_bytes(bytes: B) -> Result<Self, String> {
             use crate::bytes::indexed::validate;
@@ -485,7 +485,7 @@ mod test {
     #[test]
     fn round_trip() {
 
-        use crate::common::{Push, HeapSize, Len, Index};
+        use crate::common::{Push, Len, Index};
         use crate::{Borrow, AsBytes, FromBytes};
 
         let mut column: ContainerOf<Result<u64, u64>> = Default::default();
@@ -495,7 +495,6 @@ mod test {
         }
 
         assert_eq!(column.len(), 200);
-        assert_eq!(column.heap_size(), (1624, 2080));
 
         for i in 0..100 {
             assert_eq!(column.get(2*i+0), Ok(i as u64));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl<T: Clone + Send + 'static> Container for Vec<T> {
 pub trait ContainerBytes : Container + for<'a> Borrow<Borrowed<'a> : AsBytes<'a> + FromBytes<'a>> { }
 impl<C: Container + for<'a> Borrow<Borrowed<'a> : AsBytes<'a> + FromBytes<'a>>> ContainerBytes for C { }
 
-pub use common::{Clear, Len, Push, IndexMut, Index, IndexAs, HeapSize, Slice, AsBytes, FromBytes};
+pub use common::{Clear, Len, Push, IndexMut, Index, IndexAs, Slice, AsBytes, FromBytes};
 /// Common traits and types that are re-used throughout the module.
 pub mod common {
 
@@ -392,42 +392,6 @@ pub mod common {
     // Slice references can be cleared.
     impl<T> Clear for &[T] {
         #[inline(always)] fn clear(&mut self) { *self = &[]; }
-    }
-
-    pub trait HeapSize {
-        /// Active (len) and allocated (cap) heap sizes in bytes.
-        /// This should not include the size of `self` itself.
-        fn heap_size(&self) -> (usize, usize) { (0, 0) }
-    }
-
-    impl HeapSize for String {
-        fn heap_size(&self) -> (usize, usize) {
-            (self.len(), self.capacity())
-        }
-    }
-    impl<T: HeapSize> HeapSize for [T] {
-        fn heap_size(&self) -> (usize, usize) {
-            let mut l = std::mem::size_of_val(self);
-            let mut c = std::mem::size_of_val(self);
-            for item in self.iter() {
-                let (il, ic) = item.heap_size();
-                l += il;
-                c += ic;
-            }
-            (l, c)
-        }
-    }
-    impl<T: HeapSize> HeapSize for Vec<T> {
-        fn heap_size(&self) -> (usize, usize) {
-            let mut l = std::mem::size_of::<T>() * self.len();
-            let mut c = std::mem::size_of::<T>() * self.capacity();
-            for item in (self[..]).iter() {
-                let (il, ic) = item.heap_size();
-                l += il;
-                c += ic;
-            }
-            (l, c)
-        }
     }
 
     /// A struct representing a slice of a range of values.

--- a/src/lookback.rs
+++ b/src/lookback.rs
@@ -3,7 +3,7 @@
 //! This has the potential to be more efficient than a list of `T` when many values repeat in
 //! close proximity. Values must be equatable, and the degree of lookback can be configured.
 
-use crate::{Options, Results, Push, Index, Len, HeapSize};
+use crate::{Options, Results, Push, Index, Len};
 
 /// A container that encodes repeated values with a `None` variant, at the cost of extra bits for every record.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -44,12 +44,6 @@ impl<TC: Index, const N: u8> Index for Repeats<TC, N> {
                 self.inner.somes.get(pos)
             },
         }
-    }
-}
-
-impl<TC: HeapSize, const N: u8> HeapSize for Repeats<TC, N> {
-    fn heap_size(&self) -> (usize, usize) {
-        self.inner.heap_size()
     }
 }
 
@@ -107,8 +101,3 @@ where
     }
 }
 
-impl<TC: HeapSize, VC: HeapSize, const N: u8> HeapSize for Lookbacks<TC, VC, N> {
-    fn heap_size(&self) -> (usize, usize) {
-        self.inner.heap_size()
-    }
-}

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -12,8 +12,6 @@ macro_rules! implement_columnable {
             type Container = Vec<$index_type>;
         }
 
-        impl crate::HeapSize for $index_type { }
-
         impl<'a> crate::AsBytes<'a> for &'a [$index_type] {
             #[inline(always)]
             fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
@@ -140,12 +138,6 @@ mod sizes {
     }
     impl<CV: Clear> Clear for Usizes<CV> { fn clear(&mut self) { self.values.clear() }}
 
-    impl<CV: HeapSize> HeapSize for Usizes<CV> {
-        fn heap_size(&self) -> (usize, usize) {
-            self.values.heap_size()
-        }
-    }
-
     impl<'a, CV: crate::AsBytes<'a>> crate::AsBytes<'a> for crate::primitive::Usizes<CV> {
         #[inline(always)]
         fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
@@ -221,12 +213,6 @@ mod sizes {
         fn push(&mut self, item: &isize) { self.values.push((*item).try_into().expect("isize must fit in a i64")) }
     }
     impl<CV: Clear> Clear for Isizes<CV> { fn clear(&mut self) { self.values.clear() }}
-
-    impl<CV: HeapSize> HeapSize for Isizes<CV> {
-        fn heap_size(&self) -> (usize, usize) {
-            self.values.heap_size()
-        }
-    }
 
     impl<'a, CV: crate::AsBytes<'a>> crate::AsBytes<'a> for crate::primitive::Isizes<CV> {
         #[inline(always)]
@@ -309,12 +295,6 @@ mod chars {
     }
     impl<CV: Clear> Clear for Chars<CV> { fn clear(&mut self) { self.values.clear() }}
 
-    impl<CV: HeapSize> HeapSize for Chars<CV> {
-        fn heap_size(&self) -> (usize, usize) {
-            self.values.heap_size()
-        }
-    }
-
     impl<'a, CV: crate::AsBytes<'a>> crate::AsBytes<'a> for Chars<CV> {
         #[inline(always)]
         fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
@@ -396,12 +376,6 @@ mod larges {
     }
     impl<CV: Clear> Clear for U128s<CV> { fn clear(&mut self) { self.values.clear() }}
 
-    impl<CV: HeapSize> HeapSize for U128s<CV> {
-        fn heap_size(&self) -> (usize, usize) {
-            self.values.heap_size()
-        }
-    }
-
     impl<'a, CV: crate::AsBytes<'a>> crate::AsBytes<'a> for U128s<CV> {
         #[inline(always)]
         fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> {
@@ -472,12 +446,6 @@ mod larges {
         fn push(&mut self, item: &i128) { self.values.push(item.to_le_bytes()) }
     }
     impl<CV: Clear> Clear for I128s<CV> { fn clear(&mut self) { self.values.clear() }}
-
-    impl<CV: HeapSize> HeapSize for I128s<CV> {
-        fn heap_size(&self) -> (usize, usize) {
-            self.values.heap_size()
-        }
-    }
 
     impl<'a, CV: crate::AsBytes<'a>> crate::AsBytes<'a> for I128s<CV> {
         #[inline(always)]
@@ -571,10 +539,6 @@ pub mod offsets {
             }
         }
 
-        impl<const K: u64> crate::HeapSize for Fixeds<K> {
-            #[inline(always)]
-            fn heap_size(&self) -> (usize, usize) { (0, 0) }
-        }
         impl<const K: u64> crate::Clear for Fixeds<K> {
             #[inline(always)]
             fn clear(&mut self) { self.count = 0; }
@@ -816,7 +780,7 @@ pub use empty::Empties;
 mod empty {
 
     use crate::common::index::CopyAs;
-    use crate::{Clear, Columnar, Container, Len, IndexMut, Index, Push, HeapSize, Borrow};
+    use crate::{Clear, Columnar, Container, Len, IndexMut, Index, Push, Borrow};
 
     #[derive(Copy, Clone, Debug, Default)]
     pub struct Empties<CC = u64> { pub count: CC, pub empty: () }
@@ -886,10 +850,6 @@ mod empty {
         }
     }
 
-    impl HeapSize for Empties {
-        #[inline(always)]
-        fn heap_size(&self) -> (usize, usize) { (0, 0) }
-    }
     impl Clear for Empties {
         #[inline(always)]
         fn clear(&mut self) { self.count = 0; }
@@ -931,7 +891,7 @@ pub use boolean::Bools;
 mod boolean {
 
     use crate::common::index::CopyAs;
-    use crate::{Container, Clear, Len, Index, IndexAs, Push, HeapSize, Borrow};
+    use crate::{Container, Clear, Len, Index, IndexAs, Push, Borrow};
 
     /// A store for maintaining `Vec<bool>`.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1085,12 +1045,6 @@ mod boolean {
         }
     }
 
-    impl<VC: HeapSize> HeapSize for Bools<VC> {
-        #[inline(always)]
-        fn heap_size(&self) -> (usize, usize) {
-            self.values.heap_size()
-        }
-    }
 }
 
 pub use duration::Durations;
@@ -1098,7 +1052,7 @@ pub use duration::Durations;
 mod duration {
 
     use std::time::Duration;
-    use crate::{Container, Len, Index, IndexAs, Push, Clear, HeapSize, Borrow};
+    use crate::{Container, Len, Index, IndexAs, Push, Clear, Borrow};
 
     // `std::time::Duration` is equivalent to `(u64, u32)`, corresponding to seconds and nanoseconds.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1212,13 +1166,5 @@ mod duration {
         }
     }
 
-    impl<SC: HeapSize, NC: HeapSize> HeapSize for Durations<SC, NC> {
-        #[inline(always)]
-        fn heap_size(&self) -> (usize, usize) {
-            let (l0, c0) = self.seconds.heap_size();
-            let (l1, c1) = self.nanoseconds.heap_size();
-            (l0 + l1, c0 + c1)
-        }
-    }
 }
 

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,7 +1,7 @@
 //! Implementations of traits for `Rc<T>`
 use std::rc::Rc;
 
-use crate::{Len, Borrow, HeapSize, AsBytes, FromBytes};
+use crate::{Len, Borrow, AsBytes, FromBytes};
 
 impl<T: Borrow> Borrow for Rc<T> {
     type Ref<'a> = T::Ref<'a> where T: 'a;
@@ -12,12 +12,6 @@ impl<T: Borrow> Borrow for Rc<T> {
 }
 impl<T: Len> Len for Rc<T> {
     #[inline(always)] fn len(&self) -> usize { self.as_ref().len() }
-}
-impl<T: HeapSize> HeapSize for Rc<T> {
-    fn heap_size(&self) -> (usize, usize) {
-        let (l, c) = self.as_ref().heap_size();
-        (l + std::mem::size_of::<Rc<T>>(), c + std::mem::size_of::<Rc<T>>())
-    }
 }
 impl<'a, T: AsBytes<'a>> AsBytes<'a> for Rc<T> {
     #[inline(always)] fn as_bytes(&self) -> impl Iterator<Item=(u64, &'a [u8])> { self.as_ref().as_bytes() }
@@ -31,7 +25,7 @@ impl<'a, T: FromBytes<'a>> FromBytes<'a> for Rc<T> {
 #[cfg(test)]
 mod tests {
     use std::rc::Rc;
-    use crate::{Borrow, Len, HeapSize, AsBytes, FromBytes};
+    use crate::{Borrow, Len, AsBytes, FromBytes};
 
     #[test]
     fn test_borrow() {
@@ -44,14 +38,6 @@ mod tests {
     fn test_len() {
         let x = Rc::new(vec![1, 2, 3]);
         assert_eq!(x.len(), 3);
-    }
-
-    #[test]
-    fn test_heap_size() {
-        let x = Rc::new(vec![1, 2, 3]);
-        let (l, c) = x.heap_size();
-        assert!(l > 0);
-        assert!(c > 0);
     }
 
     #[test]

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,4 +1,4 @@
-use super::{Clear, Columnar, Container, Len, Index, IndexAs, Push, HeapSize, Borrow};
+use super::{Clear, Columnar, Container, Len, Index, IndexAs, Push, Borrow};
 
 /// A stand-in for `Vec<String>`.
 ///
@@ -210,11 +210,4 @@ impl<BC: Clear, VC: Clear> Clear for Strings<BC, VC> {
         self.values.clear();
     }
 }
-impl<BC: HeapSize, VC: HeapSize> HeapSize for Strings<BC, VC> {
-    #[inline(always)]
-    fn heap_size(&self) -> (usize, usize) {
-        let (l0, c0) = self.bounds.heap_size();
-        let (l1, c1) = self.values.heap_size();
-        (l0 + l1, c0 + c1)
-    }
-}
+

--- a/src/sums.rs
+++ b/src/sums.rs
@@ -14,7 +14,7 @@ pub mod rank_select {
 
     use crate::primitive::Bools;
     use crate::common::index::CopyAs;
-    use crate::{Borrow, Len, Index, IndexAs, Push, Clear, HeapSize};
+    use crate::{Borrow, Len, Index, IndexAs, Push, Clear};
 
     /// A store for maintaining `Vec<bool>` with fast `rank` and `select` access.
     ///
@@ -156,19 +156,12 @@ pub mod rank_select {
             self.values.clear();
         }
     }
-    impl<CC: HeapSize, VC: HeapSize> HeapSize for RankSelect<CC, VC> {
-        fn heap_size(&self) -> (usize, usize) {
-            let (l0, c0) = self.counts.heap_size();
-            let (l1, c1) = self.values.heap_size();
-            (l0 + l1, c0 + c1)
-        }
-    }
 }
 
 pub mod result {
 
     use crate::common::index::CopyAs;
-    use crate::{Clear, Columnar, Container, Len, IndexMut, Index, IndexAs, Push, HeapSize, Borrow};
+    use crate::{Clear, Columnar, Container, Len, IndexMut, Index, IndexAs, Push, Borrow};
     use crate::RankSelect;
 
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -375,15 +368,6 @@ pub mod result {
         }
     }
 
-    impl<SC: HeapSize, TC: HeapSize> HeapSize for Results<SC, TC> {
-        fn heap_size(&self) -> (usize, usize) {
-            let (l0, c0) = self.oks.heap_size();
-            let (l1, c1) = self.errs.heap_size();
-            let (li, ci) = self.indexes.heap_size();
-            (l0 + l1 + li, c0 + c1 + ci)
-        }
-    }
-
     impl<SC, TC, CC, VC, WC> Results<SC, TC, CC, VC, WC> {
         /// Returns ok values if no errors exist.
         pub fn unwrap(self) -> SC where TC: Len {
@@ -409,7 +393,7 @@ pub mod result {
         #[test]
         fn round_trip() {
 
-            use crate::common::{Index, Push, HeapSize, Len};
+            use crate::common::{Index, Push, Len};
 
             let mut column: crate::ContainerOf<Result<u64, u64>> = Default::default();
             for i in 0..100 {
@@ -418,7 +402,6 @@ pub mod result {
             }
 
             assert_eq!(column.len(), 200);
-            assert_eq!(column.heap_size(), (1624, 2080));
 
             for i in 0..100 {
                 assert_eq!(column.get(2*i+0), Ok(i as u64));
@@ -432,7 +415,6 @@ pub mod result {
             }
 
             assert_eq!(column.len(), 200);
-            assert_eq!(column.heap_size(), (924, 1184));
 
             for i in 0..100 {
                 assert_eq!(column.get(2*i+0), Ok(i as u64));
@@ -445,7 +427,7 @@ pub mod result {
 pub mod option {
 
     use crate::common::index::CopyAs;
-    use crate::{Clear, Columnar, Container, Len, IndexMut, Index, IndexAs, Push, HeapSize, Borrow};
+    use crate::{Clear, Columnar, Container, Len, IndexMut, Index, IndexAs, Push, Borrow};
     use crate::RankSelect;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -630,19 +612,11 @@ pub mod option {
         }
     }
 
-    impl<TC: HeapSize> HeapSize for Options<TC> {
-        fn heap_size(&self) -> (usize, usize) {
-            let (l0, c0) = self.somes.heap_size();
-            let (li, ci) = self.indexes.heap_size();
-            (l0 + li, c0 + ci)
-        }
-    }
-
     #[cfg(test)]
     mod test {
 
         use crate::Columnar;
-        use crate::common::{Index, HeapSize, Len};
+        use crate::common::{Index, Len};
         use crate::Options;
 
         #[test]
@@ -651,7 +625,6 @@ pub mod option {
             let store: Options<Vec<i32>> = Columnar::into_columns((0..100).map(Some));
             assert_eq!(store.len(), 100);
             assert!((&store).index_iter().zip(0..100).all(|(a, b)| a == Some(&b)));
-            assert_eq!(store.heap_size(), (408, 544));
         }
 
         #[test]
@@ -660,7 +633,6 @@ pub mod option {
             assert_eq!(store.len(), 100);
             let foo = &store;
             assert!(foo.index_iter().zip(0..100).all(|(a, _b)| a == None));
-            assert_eq!(store.heap_size(), (8, 32));
         }
 
         #[test]
@@ -669,7 +641,6 @@ pub mod option {
             let store: Options<Vec<i32>>  = Columnar::into_columns((0..100).map(|x| if x % 2 == 0 { Some(x) } else { None }));
             assert_eq!(store.len(), 100);
             assert!((&store).index_iter().zip(0..100).all(|(a, b)| a == if b % 2 == 0 { Some(&b) } else { None }));
-            assert_eq!(store.heap_size(), (208, 288));
         }
     }
 }
@@ -677,7 +648,7 @@ pub mod option {
 pub mod discriminant {
 
     use crate::common::index::CopyAs;
-    use crate::{Clear, Container, Len, Index, IndexAs, HeapSize, Borrow};
+    use crate::{Clear, Container, Len, Index, IndexAs, Borrow};
 
     /// Tracks variant discriminants and offsets for enum containers.
     ///
@@ -819,13 +790,6 @@ pub mod discriminant {
         }
     }
 
-    impl<CVar: HeapSize, COff: HeapSize> HeapSize for Discriminant<CVar, COff> {
-        fn heap_size(&self) -> (usize, usize) {
-            let (l0, c0) = self.variant.heap_size();
-            let (l1, c1) = self.offset.heap_size();
-            (l0 + l1, c0 + c1)
-        }
-    }
 
     // AsBytes for borrowed form
     impl<'a> crate::AsBytes<'a> for Discriminant<&'a [u8], &'a [u64], &'a u64> {

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use crate::{Columnar, Container, Borrow, Len, Clear, HeapSize, Index, IndexMut, Push};
+use crate::{Columnar, Container, Borrow, Len, Clear, Index, IndexMut, Push};
 
 // Implementations for tuple types.
 // These are all macro based, because the implementations are very similar.
@@ -98,16 +98,6 @@ macro_rules! tuple_impl {
                 $($name.clear();)*
             }
         }
-        impl<$($name: HeapSize),*> HeapSize for ($($name,)*) {
-            #[inline(always)]
-            fn heap_size(&self) -> (usize, usize) {
-                let ($($name,)*) = self;
-                let mut l = 0;
-                let mut c = 0;
-                $(let (l0, c0) = $name.heap_size(); l += l0; c += c0;)*
-                (l, c)
-            }
-        }
         impl<$($name: Index),*> Index for ($($name,)*) {
             type Ref = ($($name::Ref,)*);
             #[inline(always)]
@@ -168,7 +158,7 @@ mod test {
     #[test]
     fn round_trip() {
 
-        use crate::common::{Index, Push, HeapSize, Len};
+        use crate::common::{Index, Push, Len};
 
         let mut column: crate::ContainerOf<(u64, u8, String)> = Default::default();
         for i in 0..100 {
@@ -177,22 +167,11 @@ mod test {
         }
 
         assert_eq!(column.len(), 200);
-        assert_eq!(column.heap_size(), (3590, 4608));
 
         for i in 0..100u64 {
             assert_eq!((&column).get((2*i+0) as usize), (&i, &(i as u8), i.to_string().as_bytes()));
             assert_eq!((&column).get((2*i+1) as usize), (&i, &(i as u8), &b""[..]));
         }
-
-        // Compare to the heap size of a `Vec<Option<usize>>`.
-        let mut column: Vec<(u64, u8, String)> = Default::default();
-        for i in 0..100 {
-            column.push((i, i as u8, i.to_string()));
-            column.push((i, i as u8, "".to_string()));
-        }
-        // NB: Rust seems to change the capacities across versions (1.88 != 1.89),
-        // so we just compare the allocated regions to avoid updating the MSRV.
-        assert_eq!(column.heap_size().0, 8190);
 
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,4 +1,4 @@
-use super::{Clear, Columnar, Container, Len, IndexMut, Index, IndexAs, Push, HeapSize, Slice, Borrow};
+use super::{Clear, Columnar, Container, Len, IndexMut, Index, IndexAs, Push, Slice, Borrow};
 
 /// A stand-in for `Vec<Vec<T>>` for complex `T`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -212,10 +212,4 @@ impl<TC: Clear, BC: Clear> Clear for Vecs<TC, BC> {
     }
 }
 
-impl<TC: HeapSize, BC: HeapSize> HeapSize for Vecs<TC, BC> {
-    fn heap_size(&self) -> (usize, usize) {
-        let (l0, c0) = self.bounds.heap_size();
-        let (l1, c1) = self.values.heap_size();
-        (l0 + l1, c0 + c1)
-    }
-}
+


### PR DESCRIPTION
Removing in favor of `AsBytes` which allows inspection of the actual byte slices. This stops reporting capacities (less important with demand paging), and instead provides precise information about the number, lengths, and alignment (!) of allocations.