### PR TITLE
Add Sequence trait for fast sequential iteration over Borrowed views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 /target
 /wip
+/.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Cargo.lock
 /target
 /wip
-/.worktrees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Sequence` trait on `Borrowed` views for fast sequential iteration; `Repeats` and `Lookbacks` skip per-element `rank()` via incremental counters and cached bitvector words, yielding ~11x faster iteration. Composition through tuples and `#[derive(Columnar)]` structs propagates the fast path automatically. Iterators consume the `Copy` borrowed view by value so the iterator lifetime is the borrowed data's inner lifetime, not any outer shell — `container.borrow().seq_iter()` works without temp-borrow dangling.
+
+### Removed
+
+- `Index::Cursor<'a>` GAT, `Index::cursor`, `Index::index_iter`, `Index::into_index_iter`, `DefaultCursor`, `impl_default_cursor!`, `CursorOf<'a, C>`. Replaced by `Sequence` on the `Borrowed` side. Callers that consumed a `&Container` iterator can construct `common::IterOwn::new(0, &container)` directly.
+
 ## [0.12.1](https://github.com/frankmcsherry/columnar/compare/columnar-v0.12.0...columnar-v0.12.1) - 2026-03-29
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,15 @@ harness = false
 [[bench]]
 name = "simd"
 harness = false
+
+[[bench]]
+name = "derived_cursor"
+harness = false
+
+[[bench]]
+name = "options_cursor"
+harness = false
+
+[[bench]]
+name = "repeats_cursor"
+harness = false

--- a/benches/derived_cursor.rs
+++ b/benches/derived_cursor.rs
@@ -1,0 +1,80 @@
+//! Bench composed-cursor vs default-cursor on derived struct containers.
+//!
+//! Focus: derived struct with a Repeats field. Composed cursor would let the
+//! Repeats field use its rank-free cursor; DefaultCursor falls back to get()
+//! which calls rank() per element.
+
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use bencher as _;
+use columnar::{Columnar, Borrow, Index, Len, Repeats, Sequence};
+
+#[derive(Columnar, Debug, PartialEq, Eq, Clone)]
+struct Row {
+    key: u64,
+    val: u64,
+}
+
+const N: u64 = 100_000;
+const KEYS: u64 = 100;
+
+fn populate() -> RowContainer<Repeats<Vec<u64>>, Vec<u64>> {
+    use columnar::common::Push;
+    let mut keys: Repeats<Vec<u64>> = Default::default();
+    let mut vals: Vec<u64> = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        Push::push(&mut keys, &(i / (N / KEYS)));
+        vals.push(i);
+    }
+    RowContainer { key: keys, val: vals }
+}
+
+fn derived_get(bencher: &mut Bencher) {
+    let container = populate();
+    let borrowed = container.borrow();
+    bencher.bytes = (N * 16) as u64;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for i in 0..borrowed.len() {
+            let row = borrowed.get(i);
+            sum = sum.wrapping_add(*row.key).wrapping_add(*row.val);
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn derived_cursor(bencher: &mut Bencher) {
+    let container = populate();
+    let borrowed = container.borrow();
+    bencher.bytes = (N * 16) as u64;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for row in borrowed.seq_iter() {
+            sum = sum.wrapping_add(*row.key).wrapping_add(*row.val);
+        }
+        bencher::black_box(sum);
+    });
+}
+
+// Hand-written tuple for comparison — already gets composed cursor.
+fn tuple_cursor(bencher: &mut Bencher) {
+    use columnar::common::Push;
+    let mut keys: Repeats<Vec<u64>> = Default::default();
+    let mut vals: Vec<u64> = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        Push::push(&mut keys, &(i / (N / KEYS)));
+        vals.push(i);
+    }
+    let container = (keys, vals);
+    let borrowed = container.borrow();
+    bencher.bytes = (N * 16) as u64;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for (k, v) in borrowed.seq_iter() {
+            sum = sum.wrapping_add(*k).wrapping_add(*v);
+        }
+        bencher::black_box(sum);
+    });
+}
+
+benchmark_group!(benches, derived_get, derived_cursor, tuple_cursor);
+benchmark_main!(benches);

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -47,7 +47,8 @@ impl Op {
                 Ok(aa.iter().map(|a| -a).collect())
             },
             (Op::Len, [.., Err(aa)]) => {
-                Ok(aa.into_index_iter().map(|a| a.len() as i32).collect())
+                use columnar::Len;
+                Ok((0..aa.len()).map(|i| aa.get(i).len() as i32).collect())
             },
             (Op::Fmt, [.., Ok(aa)]) => {
                 let mut result = Strings::default();

--- a/benches/options_cursor.rs
+++ b/benches/options_cursor.rs
@@ -1,0 +1,94 @@
+//! Bench Options/Results cursor: does cursor speed up iteration vs get()?
+//!
+//! Default impl uses DefaultCursor which delegates to get() → rank() per element.
+//! Same rank() overhead as Repeats before specialization.
+
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use columnar::{Borrow, Index, Len, Options, Results, Sequence};
+
+const N: u64 = 100_000;
+
+fn options_populate() -> Options<Vec<u64>> {
+    use columnar::common::Push;
+    let mut opts: Options<Vec<u64>> = Default::default();
+    for i in 0..N {
+        if i % 3 == 0 { Push::push(&mut opts, None::<u64>); }
+        else { Push::push(&mut opts, Some(i)); }
+    }
+    opts
+}
+
+fn options_get(bencher: &mut Bencher) {
+    let opts = options_populate();
+    let borrowed = opts.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for i in 0..borrowed.len() {
+            if let Some(v) = borrowed.get(i) {
+                sum = sum.wrapping_add(*v);
+            }
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn options_cursor(bencher: &mut Bencher) {
+    let opts = options_populate();
+    let borrowed = opts.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for v in borrowed.seq_iter() {
+            if let Some(v) = v {
+                sum = sum.wrapping_add(*v);
+            }
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn results_populate() -> Results<Vec<u64>, Vec<u32>> {
+    use columnar::common::Push;
+    let mut r: Results<Vec<u64>, Vec<u32>> = Default::default();
+    for i in 0..N {
+        if i % 5 == 0 { Push::push(&mut r, Err::<u64, u32>(i as u32)); }
+        else { Push::push(&mut r, Ok::<u64, u32>(i)); }
+    }
+    r
+}
+
+fn results_get(bencher: &mut Bencher) {
+    let r = results_populate();
+    let borrowed = r.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for i in 0..borrowed.len() {
+            match borrowed.get(i) {
+                Ok(v) => sum = sum.wrapping_add(*v),
+                Err(e) => sum = sum.wrapping_add(*e as u64),
+            }
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn results_cursor(bencher: &mut Bencher) {
+    let r = results_populate();
+    let borrowed = r.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for v in borrowed.seq_iter() {
+            match v {
+                Ok(v) => sum = sum.wrapping_add(*v),
+                Err(e) => sum = sum.wrapping_add(*e as u64),
+            }
+        }
+        bencher::black_box(sum);
+    });
+}
+
+benchmark_group!(benches, options_get, options_cursor, results_get, results_cursor);
+benchmark_main!(benches);

--- a/benches/repeats_cursor.rs
+++ b/benches/repeats_cursor.rs
@@ -1,0 +1,79 @@
+//! Direct Repeats / Lookbacks cursor bench: measure rank-free iteration win.
+
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use columnar::{Borrow, Index, Len, Repeats, Lookbacks, Sequence};
+
+const N: u64 = 100_000;
+
+fn repeats_populate(run: u64) -> Repeats<Vec<u64>> {
+    use columnar::common::Push;
+    let mut r: Repeats<Vec<u64>> = Default::default();
+    for i in 0..N {
+        Push::push(&mut r, &(i / run));
+    }
+    r
+}
+
+fn repeats_get(bencher: &mut Bencher) {
+    let r = repeats_populate(100);
+    let borrowed = r.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for i in 0..borrowed.len() {
+            sum = sum.wrapping_add(*borrowed.get(i));
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn repeats_cursor(bencher: &mut Bencher) {
+    let r = repeats_populate(100);
+    let borrowed = r.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for v in borrowed.seq_iter() {
+            sum = sum.wrapping_add(*v);
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn lookbacks_populate() -> Lookbacks<Vec<u64>> {
+    use columnar::common::Push;
+    let mut l: Lookbacks<Vec<u64>> = Default::default();
+    for i in 0..N {
+        Push::push(&mut l, &(i % 17));
+    }
+    l
+}
+
+fn lookbacks_get(bencher: &mut Bencher) {
+    let l = lookbacks_populate();
+    let borrowed = l.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for i in 0..borrowed.len() {
+            sum = sum.wrapping_add(*borrowed.get(i));
+        }
+        bencher::black_box(sum);
+    });
+}
+
+fn lookbacks_cursor(bencher: &mut Bencher) {
+    let l = lookbacks_populate();
+    let borrowed = l.borrow();
+    bencher.bytes = N * 8;
+    bencher.iter(|| {
+        let mut sum = 0u64;
+        for v in borrowed.seq_iter() {
+            sum = sum.wrapping_add(*v);
+        }
+        bencher::black_box(sum);
+    });
+}
+
+benchmark_group!(benches, repeats_get, repeats_cursor, lookbacks_get, lookbacks_cursor);
+benchmark_main!(benches);

--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -74,12 +74,13 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
     let derive = quote! { #[derive(Copy, Clone, Debug, Default)] };
 
     let container_struct = {
+        let field_docs: Vec<String> = names.iter().map(|n| format!("Container for `{}`.", n)).collect();
         quote! {
             /// Derived columnar container for a struct.
             #derive
             #vis struct #c_ident < #(#container_types),* >{
                 #(
-                    /// Container for #names.
+                    #[doc = #field_docs]
                     pub #names : #container_types,
                 )*
             }
@@ -101,13 +102,14 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
             quote! {}
         };
 
+        let field_docs: Vec<String> = names.iter().map(|n| format!("Field for `{}`.", n)).collect();
         quote! {
             /// Derived columnar reference for a struct.
             #[derive(Copy, Clone, Debug)]
             #attr
             #vis struct #r_ident #ty_gen {
                 #(
-                    /// Field for #names.
+                    #[doc = #field_docs]
                     pub #names : #reference_types,
                 )*
             }
@@ -217,6 +219,55 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
                 fn push(&mut self, item: #index_type) {
                     #destructure_self
                     #(#push)*
+                }
+            }
+        }
+    };
+
+    let seq_iter_struct = {
+        let seq_iter_ident = syn::Ident::new(&format!("{}SeqIter", c_ident), c_ident.span());
+        let first_name = &names[0];
+        quote! {
+            /// Composed SeqIter for the derived container: zips field `Sequence::Iter`s.
+            #vis struct #seq_iter_ident < #(#container_types),* > {
+                #( pub #names: #container_types, )*
+            }
+
+            impl< #(#container_types: Iterator),* > Iterator for #seq_iter_ident < #(#container_types),* > {
+                type Item = #r_ident < #(#container_types::Item,)* >;
+                #[inline(always)]
+                fn next(&mut self) -> Option<Self::Item> {
+                    Some(#r_ident { #( #names: self.#names.next()?, )* })
+                }
+                #[inline(always)]
+                fn size_hint(&self) -> (usize, Option<usize>) {
+                    self.#first_name.size_hint()
+                }
+            }
+
+            impl< #(#container_types: ExactSizeIterator),* > ExactSizeIterator for #seq_iter_ident < #(#container_types),* > {}
+        }
+    };
+
+    let sequence_impl = {
+        let seq_iter_ident = syn::Ident::new(&format!("{}SeqIter", c_ident), c_ident.span());
+        let impl_gen = quote! { < #(#container_types: ::columnar::Sequence),* > };
+        let ty_gen = quote! { < #(#container_types),* > };
+
+        quote! {
+            impl #impl_gen ::columnar::Sequence for #c_ident #ty_gen
+            where
+                #c_ident #ty_gen : Copy + ::columnar::Len,
+            {
+                type Ref = #r_ident < #(<#container_types as ::columnar::Sequence>::Ref,)* >;
+                type Iter = #seq_iter_ident < #(<#container_types as ::columnar::Sequence>::Iter,)* >;
+                #[inline(always)]
+                fn seq_iter(self) -> Self::Iter {
+                    #seq_iter_ident { #( #names: <#container_types as ::columnar::Sequence>::seq_iter(self.#names), )* }
+                }
+                #[inline(always)]
+                fn seq_iter_range(self, range: ::core::ops::Range<usize>) -> Self::Iter {
+                    #seq_iter_ident { #( #names: <#container_types as ::columnar::Sequence>::seq_iter_range(self.#names, range.clone()), )* }
                 }
             }
         }
@@ -417,6 +468,7 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
 
         #container_struct
         #reference_struct
+        #seq_iter_struct
 
         #partial_eq
 
@@ -433,6 +485,8 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
         #from_bytes
 
         #columnar_impl
+
+        #sequence_impl
 
     }.into()
 }

--- a/src/adts/art.rs
+++ b/src/adts/art.rs
@@ -1,4 +1,4 @@
-//! Adaptive Radix Trees (https://db.in.tum.de/~leis/papers/ART.pdf).
+//! Adaptive Radix Trees (<https://db.in.tum.de/~leis/papers/ART.pdf>).
 //!
 //! This ADT represents an unordered collection of byte sequences as a tree.
 //! Like a trie, the paths down the tree correspond to byte sequences, and 

--- a/src/adts/tree.rs
+++ b/src/adts/tree.rs
@@ -110,6 +110,22 @@ impl<TC: Index + Copy, BC: IndexAs<u64> + Len + Copy> Index for Trees<TC, BC> {
         }
     }
 }
+impl<TC: Index + Copy, BC: IndexAs<u64> + Len + Copy> crate::Sequence for Trees<TC, BC>
+where
+    Self: Copy,
+{
+    type Ref = <Self as Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
+    }
+}
 
 impl<'a, TC, BC: IndexAs<u64> + Len> Index for &'a Trees<TC, BC>
 where
@@ -127,6 +143,23 @@ where
             values: &self.values,
             bounds: &self.bounds,
         }
+    }
+}
+impl<'a, TC, BC: IndexAs<u64> + Len> crate::Sequence for &'a Trees<TC, BC>
+where
+    &'a TC: Index,
+    &'a BC: IndexAs<u64>,
+{
+    type Ref = <Self as Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
     }
 }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -69,6 +69,22 @@ impl<C: Index> Index for Boxed<C> {
     type Ref = Boxed<C::Ref>;
     #[inline(always)] fn get(&self, index: usize) -> Self::Ref { Boxed(self.0.get(index)) }
 }
+impl<C: Index + Len> crate::Sequence for Boxed<C>
+where
+    Self: Copy,
+{
+    type Ref = <Self as crate::Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
+    }
+}
 impl<C: IndexMut> IndexMut for Boxed<C> {
     type IndexMut<'a> = Boxed<C::IndexMut<'a>> where Self: 'a;
     #[inline(always)] fn get_mut(&mut self, index: usize) -> Self::IndexMut<'_> { Boxed(self.0.get_mut(index)) }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -508,7 +508,7 @@ pub mod stash {
                 },
             }
         }
-        /// The number of bytes needed to write the contents using the [`indexed`] encoder.
+        /// The number of bytes needed to write the contents using the [`indexed`](crate::bytes::indexed) encoder.
         ///
         /// This may be less than the length of the contained bytes or words, if they overshoot.
         pub fn length_in_bytes(&self) -> usize { crate::bytes::indexed::length_in_bytes(&self.borrow()) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,17 @@ use alloc::vec::Vec;
 extern crate columnar_derive;
 pub use columnar_derive::Columnar;
 
+// Allow the derive macro's `::columnar::...` paths to resolve to this crate
+// from within its own tests.
+#[cfg(test)]
+extern crate self as columnar;
+
 pub mod adts;
 pub mod boxed;
 pub mod bytes;
 pub mod lookback;
 pub mod primitive;
+pub mod sequence;
 pub mod string;
 pub mod sums;
 pub mod vector;
@@ -35,6 +41,7 @@ pub use vector::Vecs;
 pub use string::Strings;
 pub use sums::{rank_select::RankSelect, result::Results, option::Options, discriminant::Discriminant};
 pub use lookback::{Repeats, Lookbacks};
+pub use sequence::Sequence;
 
 /// A type that can be represented in columnar form.
 ///
@@ -251,11 +258,24 @@ pub mod common {
     /// There are several traits, with a core distinction being whether the returned reference depends on the lifetime of `&self`.
     /// For one trait `Index` the result does not depend on this lifetime.
     /// There is a third trait `IndexMut` that allows mutable access, that may be less commonly implemented.
+    ///
+    /// # Design notes
+    ///
+    /// ## `Ref` is not a GAT, deliberately
+    ///
+    /// Borrowed containers (e.g. `&'a [T]`, `Bools<&'a [u64], &'a [u64]>`) carry their own
+    /// lifetime, and we want `get()` to return references tied to *that* lifetime — not to
+    /// the `&self` borrow of the call. A GAT `Ref<'a>` would unify those lifetimes and
+    /// force every returned reference to live only as long as the `&self` borrow, losing
+    /// the property that borrowed containers can hand out refs at their own lifetime.
+    ///
+    /// Sequential iteration lives on the separate [`crate::Sequence`] trait, implemented
+    /// on `Copy` borrowed types. Specialized fast paths (e.g. [`crate::Repeats`],
+    /// [`crate::Lookbacks`], tuples, derived structs) live under `Sequence::Iter`.
     pub mod index {
 
         use alloc::vec::Vec;
         use crate::Len;
-        use crate::common::IterOwn;
 
         /// A type that can be mutably accessed by `usize`.
         pub trait IndexMut {
@@ -284,11 +304,13 @@ pub mod common {
             #[inline(always)] fn get_mut(&mut self, index: usize) -> Self::IndexMut<'_> { &mut self[index] }
         }
 
-        /// A type that can be accessed by `usize` but without borrowing `self`.
+        /// A type that can be accessed by `usize` but without borrowing `self`
+        /// for the returned reference.
         ///
-        /// This can be useful for types which include their own lifetimes, and
-        /// which wish to express that their reference has the same lifetime.
-        /// In the GAT `Index`, the `Ref<'_>` lifetime would be tied to `&self`.
+        /// [`Self::Ref`] is not a GAT: its lifetime is fixed by the container
+        /// rather than tied to `&self`. This lets borrowed containers return
+        /// references at their own lifetime, outliving the `&self` borrow.
+        /// See the module docs for the full rationale.
         ///
         /// This trait may be challenging to implement for owning containers,
         /// for example `Vec<_>`, which would need their `Ref` type to depend
@@ -301,6 +323,10 @@ pub mod common {
         /// do not then go on to examine the values. If you plan to access a field
         /// (for tuples or structs) or variant match (for enums) you should perform
         /// this before calling `get(index)` when able.
+        ///
+        /// For sequential iteration, prefer [`crate::Sequence`] on the borrowed form:
+        /// it may be significantly faster than repeated `get()` by avoiding per-element
+        /// setup (such as `rank()` in [`crate::Repeats`] / [`crate::Lookbacks`]).
         pub trait Index {
             /// The type returned by the `get` method.
             ///
@@ -318,32 +344,22 @@ pub mod common {
                 if self.is_empty() { None }
                 else { Some(self.get(self.len()-1)) }
             }
-            /// Converts `&self` into an iterator.
-            ///
-            /// This has an awkward name to avoid collision with `iter()`, which may also be implemented.
-            #[inline(always)]
-            fn index_iter(&self) -> IterOwn<&Self> {
-                IterOwn {
-                    index: 0,
-                    slice: self,
-                }
-            }
-            /// Converts `self` into an iterator.
-            ///
-            /// This has an awkward name to avoid collision with `into_iter()`, which may also be implemented.
-            #[inline(always)]
-            fn into_index_iter(self) -> IterOwn<Self> where Self: Sized {
-                IterOwn {
-                    index: 0,
-                    slice: self,
-                }
-            }
         }
 
         // These implementations aim to reveal a longer lifetime, or to copy results to avoid a lifetime.
         impl<'a, T> Index for &'a [T] {
             type Ref = &'a T;
             #[inline(always)] fn get(&self, index: usize) -> Self::Ref { &self[index] }
+        }
+        impl<'a, T> crate::Sequence for &'a [T] {
+            type Ref = &'a T;
+            type Iter = core::slice::Iter<'a, T>;
+            #[inline(always)]
+            fn seq_iter(self) -> Self::Iter { self.iter() }
+            #[inline(always)]
+            fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+                self[range].iter()
+            }
         }
         impl<T: Copy> Index for [T] {
             type Ref = T;
@@ -356,6 +372,16 @@ pub mod common {
         impl<'a, T> Index for &'a Vec<T> {
             type Ref = &'a T;
             #[inline(always)] fn get(&self, index: usize) -> Self::Ref { &self[index] }
+        }
+        impl<'a, T> crate::Sequence for &'a Vec<T> {
+            type Ref = &'a T;
+            type Iter = core::slice::Iter<'a, T>;
+            #[inline(always)]
+            fn seq_iter(self) -> Self::Iter { self.iter() }
+            #[inline(always)]
+            fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+                self[range].iter()
+            }
         }
         impl<T: Copy> Index for Vec<T> {
             type Ref = T;
@@ -554,6 +580,21 @@ pub mod common {
             (&self.slice).get(self.lower + index)
         }
     }
+    impl<'a, S> crate::Sequence for &'a Slice<S>
+    where
+        &'a S: crate::Index + crate::Sequence<Ref = <&'a S as crate::Index>::Ref>,
+    {
+        type Ref = <&'a S as crate::Index>::Ref;
+        type Iter = <&'a S as crate::Sequence>::Iter;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            (&self.slice).seq_iter_range(self.lower..self.upper)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            (&self.slice).seq_iter_range(self.lower + range.start..self.lower + range.end)
+        }
+    }
 
     impl<S: IndexMut> IndexMut for Slice<S> {
         type IndexMut<'a> = S::IndexMut<'a> where S: 'a;
@@ -568,8 +609,9 @@ pub mod common {
         ///
         /// This method exists rather than an `IntoIterator` implementation to avoid
         /// a conflicting implementation for pushing an `I: IntoIterator` into `Vecs`.
+        /// Uses the slow `get()`-based path because the iterator owns the `Slice`.
         pub fn into_iter(self) -> IterOwn<Slice<S>> {
-            self.into_index_iter()
+            IterOwn::new(0, self)
         }
     }
 
@@ -579,21 +621,28 @@ pub mod common {
         }
     }
 
+    /// Owned iterator adapter used by [`Slice::into_iter`] — calls `get()` per element.
     pub struct IterOwn<S> {
         index: usize,
         slice: S,
+        end: Option<usize>,
     }
 
     impl<S> IterOwn<S> {
         pub fn new(index: usize, slice: S) -> Self {
-            Self { index, slice }
+            Self { index, slice, end: None }
+        }
+        /// Construct with an explicit `end` (exclusive).
+        pub fn with_range(slice: S, range: core::ops::Range<usize>) -> Self {
+            Self { index: range.start, slice, end: Some(range.end) }
         }
     }
 
     impl<S: Index + Len> Iterator for IterOwn<S> {
         type Item = S::Ref;
         #[inline(always)] fn next(&mut self) -> Option<Self::Item> {
-            if self.index < self.slice.len() {
+            let end = self.end.unwrap_or_else(|| self.slice.len());
+            if self.index < end {
                 let result = self.slice.get(self.index);
                 self.index += 1;
                 Some(result)
@@ -603,7 +652,9 @@ pub mod common {
         }
         #[inline(always)]
         fn size_hint(&self) -> (usize, Option<usize>) {
-            (self.slice.len() - self.index, Some(self.slice.len() - self.index))
+            let end = self.end.unwrap_or_else(|| self.slice.len());
+            let remaining = end - self.index;
+            (remaining, Some(remaining))
         }
     }
 

--- a/src/lookback.rs
+++ b/src/lookback.rs
@@ -48,6 +48,99 @@ impl<TC: Index, CC: IndexAs<u64> + Len, VC: IndexAs<u64> + Len, WC: IndexAs<u64>
     }
 }
 
+/// Iterator for sequential access to a [`Repeats::Borrowed`] view.
+///
+/// Avoids per-element `rank()` by maintaining the count of `Some` values
+/// incrementally, and caches the current bitvector word so only one fetch
+/// per 64 elements happens instead of per element. Holds the Borrowed by
+/// value; its lifetime is the Borrowed's inner `'a`, not any outer shell.
+pub struct RepeatsSeqIter<TC, CC, VC, WC> {
+    inner: Options<TC, CC, VC, WC>,
+    cursor: usize,
+    end: usize,
+    somes_cursor: usize,
+    cached_word: u64,
+    word_index: usize,
+}
+
+impl<TC: Index, CC: IndexAs<u64> + Len, VC: IndexAs<u64> + Len, WC: IndexAs<u64>> RepeatsSeqIter<TC, CC, VC, WC> {
+    #[inline(always)]
+    fn fetch_word(&self, block: usize) -> u64 {
+        if block == self.inner.indexes.values.values.len() {
+            self.inner.indexes.values.tail.index_as(0)
+        } else {
+            self.inner.indexes.values.values.index_as(block)
+        }
+    }
+}
+
+impl<TC: Index + Copy, CC: IndexAs<u64> + Len + Copy, VC: IndexAs<u64> + Len + Copy, WC: IndexAs<u64> + Copy> Iterator for RepeatsSeqIter<TC, CC, VC, WC> {
+    type Item = TC::Ref;
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor < self.end {
+            let block = self.cursor / 64;
+            let bit = self.cursor % 64;
+            if block != self.word_index {
+                self.word_index = block;
+                self.cached_word = self.fetch_word(block);
+            }
+            if (self.cached_word >> bit) & 1 == 1 {
+                self.somes_cursor += 1;
+            }
+            self.cursor += 1;
+            debug_assert!(self.somes_cursor > 0, "Repeats container has no leading Some value");
+            Some(self.inner.somes.get(self.somes_cursor - 1))
+        } else {
+            None
+        }
+    }
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.cursor;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<TC: Index + Copy, CC: IndexAs<u64> + Len + Copy, VC: IndexAs<u64> + Len + Copy, WC: IndexAs<u64> + Copy> ExactSizeIterator for RepeatsSeqIter<TC, CC, VC, WC> {}
+
+impl<TC, CC, VC, WC> crate::Sequence for Repeats<TC, CC, VC, WC>
+where
+    Repeats<TC, CC, VC, WC>: Copy + Index<Ref = TC::Ref>,
+    TC: Index + Copy,
+    CC: IndexAs<u64> + Len + Copy,
+    VC: IndexAs<u64> + Len + Copy,
+    WC: IndexAs<u64> + Copy,
+{
+    type Ref = TC::Ref;
+    type Iter = RepeatsSeqIter<TC, CC, VC, WC>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = self.len();
+        self.seq_iter_range(0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        let somes_cursor = if range.is_empty() { 0 } else { self.inner.indexes.rank(range.start) };
+        let block = range.start / 64;
+        let cached_word = if range.is_empty() {
+            0
+        } else if block == self.inner.indexes.values.values.len() {
+            self.inner.indexes.values.tail.index_as(0)
+        } else {
+            self.inner.indexes.values.values.index_as(block)
+        };
+        RepeatsSeqIter {
+            inner: self.inner,
+            cursor: range.start,
+            end: range.end,
+            somes_cursor,
+            cached_word,
+            word_index: block,
+        }
+    }
+}
+
 impl<'a, TC> Index for &'a Repeats<TC>
 where
     &'a TC: Index,
@@ -168,6 +261,104 @@ impl<TC: Index, VC: IndexAs<u8>, CC: IndexAs<u64> + Len, RC: IndexAs<u64> + Len,
         } else {
             let back: u8 = self.inner.errs.index_as(index - rank);
             self.inner.oks.get(rank - 1 - (back as usize))
+        }
+    }
+}
+
+/// Iterator for sequential access to a [`Lookbacks::Borrowed`] view.
+///
+/// Avoids per-element `rank()` by maintaining the count of `Ok` values
+/// incrementally, and caches the current bitvector word so only one fetch
+/// per 64 elements happens instead of per element.
+pub struct LookbacksSeqIter<TC, VC, CC, RC, WC> {
+    inner: Results<TC, VC, CC, RC, WC>,
+    cursor: usize,
+    end: usize,
+    oks_cursor: usize,
+    cached_word: u64,
+    word_index: usize,
+}
+
+impl<TC: Index, VC: IndexAs<u8>, CC: IndexAs<u64> + Len, RC: IndexAs<u64> + Len, WC: IndexAs<u64>> LookbacksSeqIter<TC, VC, CC, RC, WC> {
+    #[inline(always)]
+    fn fetch_word(&self, block: usize) -> u64 {
+        if block == self.inner.indexes.values.values.len() {
+            self.inner.indexes.values.tail.index_as(0)
+        } else {
+            self.inner.indexes.values.values.index_as(block)
+        }
+    }
+}
+
+impl<TC: Index + Copy, VC: IndexAs<u8> + Copy, CC: IndexAs<u64> + Len + Copy, RC: IndexAs<u64> + Len + Copy, WC: IndexAs<u64> + Copy> Iterator for LookbacksSeqIter<TC, VC, CC, RC, WC> {
+    type Item = TC::Ref;
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor < self.end {
+            let block = self.cursor / 64;
+            let bit = self.cursor % 64;
+            if block != self.word_index {
+                self.word_index = block;
+                self.cached_word = self.fetch_word(block);
+            }
+            let result = if (self.cached_word >> bit) & 1 == 1 {
+                let item = self.inner.oks.get(self.oks_cursor);
+                self.oks_cursor += 1;
+                item
+            } else {
+                debug_assert!(self.oks_cursor > 0, "Lookbacks container has no leading Ok value");
+                let back: u8 = self.inner.errs.index_as(self.cursor - self.oks_cursor);
+                self.inner.oks.get(self.oks_cursor - 1 - (back as usize))
+            };
+            self.cursor += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.cursor;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<TC: Index + Copy, VC: IndexAs<u8> + Copy, CC: IndexAs<u64> + Len + Copy, RC: IndexAs<u64> + Len + Copy, WC: IndexAs<u64> + Copy> ExactSizeIterator for LookbacksSeqIter<TC, VC, CC, RC, WC> {}
+
+impl<TC, VC, CC, RC, WC, const N: u8> crate::Sequence for Lookbacks<TC, VC, CC, RC, WC, N>
+where
+    Lookbacks<TC, VC, CC, RC, WC, N>: Copy + Index<Ref = TC::Ref>,
+    TC: Index + Copy,
+    VC: IndexAs<u8> + Copy,
+    CC: IndexAs<u64> + Len + Copy,
+    RC: IndexAs<u64> + Len + Copy,
+    WC: IndexAs<u64> + Copy,
+{
+    type Ref = TC::Ref;
+    type Iter = LookbacksSeqIter<TC, VC, CC, RC, WC>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = self.len();
+        self.seq_iter_range(0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        let oks_cursor = if range.is_empty() { 0 } else { self.inner.indexes.rank(range.start) };
+        let block = range.start / 64;
+        let cached_word = if range.is_empty() {
+            0
+        } else if block == self.inner.indexes.values.values.len() {
+            self.inner.indexes.values.tail.index_as(0)
+        } else {
+            self.inner.indexes.values.values.index_as(block)
+        };
+        LookbacksSeqIter {
+            inner: self.inner,
+            cursor: range.start,
+            end: range.end,
+            oks_cursor,
+            cached_word,
+            word_index: block,
         }
     }
 }
@@ -575,6 +766,112 @@ mod test {
         let borrowed = lookbacks.borrow();
         for i in 0..100u64 {
             assert_eq!(*borrowed.get(i as usize), i * 1000);
+        }
+    }
+
+    // --- sequence iteration tests ---
+
+    #[test]
+    fn seq_iter_exact_size() {
+        use crate::Sequence;
+        let repeats = repeats_from(&[1, 1, 2, 3, 3]);
+        let borrowed = repeats.borrow();
+        let iter = borrowed.seq_iter_range(1..4);
+        assert_eq!(iter.len(), 3);
+    }
+
+    #[test]
+    fn seq_iter_all_repeats() {
+        use crate::Sequence;
+        let mut repeats: Repeats<Vec<u64>> = Default::default();
+        for _ in 0..100 {
+            repeats.push(&42u64);
+        }
+        let borrowed = repeats.borrow();
+        let values: Vec<u64> = borrowed.seq_iter_range(0..100).map(|x| *x).collect();
+        assert!(values.iter().all(|&x| x == 42));
+        assert_eq!(values.len(), 100);
+    }
+
+    #[test]
+    fn lookbacks_seq_iter_full() {
+        use crate::Sequence;
+        let lookbacks = lookbacks_from(&[10, 20, 10, 30, 20]);
+        let borrowed = lookbacks.borrow();
+        let values: Vec<u64> = borrowed.seq_iter().map(|x| *x).collect();
+        assert_eq!(values, vec![10, 20, 10, 30, 20]);
+    }
+
+    #[test]
+    fn repeats_seq_iter_parity() {
+        use crate::Sequence;
+        let mut repeats: Repeats<Vec<u64>> = Default::default();
+        for i in 0..300u64 {
+            repeats.push(&(i / 3));
+        }
+        let borrowed = repeats.borrow();
+        let via_seq: Vec<u64> = borrowed.seq_iter().map(|x| *x).collect();
+        let via_get: Vec<u64> = (0..borrowed.len()).map(|i| *borrowed.get(i)).collect();
+        assert_eq!(via_seq, via_get);
+    }
+
+    #[test]
+    fn repeats_seq_iter_range_word_boundaries() {
+        use crate::Sequence;
+        let mut repeats: Repeats<Vec<u64>> = Default::default();
+        for i in 0..300u64 {
+            repeats.push(&(i / 5));
+        }
+        let borrowed = repeats.borrow();
+        let probes = [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 257, 299];
+        for &start in &probes {
+            for &end in &probes {
+                if end < start { continue; }
+                let via_seq: Vec<u64> = borrowed.seq_iter_range(start..end).map(|x| *x).collect();
+                let via_get: Vec<u64> = (start..end).map(|i| *borrowed.get(i)).collect();
+                assert_eq!(via_seq, via_get, "mismatch at range {}..{}", start, end);
+            }
+        }
+    }
+
+    #[test]
+    fn repeats_seq_iter_empty_range() {
+        use crate::Sequence;
+        let repeats = repeats_from(&[1, 2, 3]);
+        let borrowed = repeats.borrow();
+        let via_seq: Vec<u64> = borrowed.seq_iter_range(2..2).map(|x| *x).collect();
+        assert!(via_seq.is_empty());
+    }
+
+    #[test]
+    fn lookbacks_seq_iter_parity() {
+        use crate::Sequence;
+        let mut lookbacks: Lookbacks<Vec<u64>> = Default::default();
+        for i in 0..300u64 {
+            lookbacks.push(&(i % 7));
+        }
+        let borrowed = lookbacks.borrow();
+        let via_seq: Vec<u64> = borrowed.seq_iter().map(|x| *x).collect();
+        let via_get: Vec<u64> = (0..borrowed.len()).map(|i| *borrowed.get(i)).collect();
+        assert_eq!(via_seq, via_get);
+    }
+
+    #[test]
+    fn lookbacks_seq_iter_range_word_boundaries() {
+        use crate::Sequence;
+        let mut lookbacks: Lookbacks<Vec<u64>> = Default::default();
+        for i in 0..300u64 {
+            lookbacks.push(&(i % 11));
+        }
+        let borrowed = lookbacks.borrow();
+        let probes = [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 257, 299];
+        for &start in &probes {
+            for &end in &probes {
+                if end < start { continue; }
+                let via_seq: Vec<u64> = borrowed.seq_iter_range(start..end).map(|x| *x).collect();
+                let via_get: Vec<u64> = (start..end).map(|i| *borrowed.get(i)).collect();
+                assert_eq!(via_seq, via_get, "mismatch at range {}..{}", start, end);
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ fn main() {
     let mut columns = Columnar::as_columns(roster.iter());
 
     // Iterated column values should match the original `roster`.
-    use columnar::Index;
-    for (col, row) in columns.into_index_iter().zip(roster) {
+    use columnar::common::IterOwn;
+    for (col, row) in IterOwn::new(0, &columns).zip(roster) {
         match (col, row) {
             (GroupReference::Solo(p0), Group::Solo(p1)) => {
                 assert_eq!(p0.0, p1.0.as_bytes());
@@ -133,14 +133,14 @@ mod test {
     #[test]
     fn round_trip() {
 
-        use columnar::Index;
+        use columnar::common::IterOwn;
 
         let test1s = vec![
             Test1 { foo: vec![1, 2, 3], bar: 4 },
             Test1 { foo: vec![5, 6, 7], bar: 8 },
         ];
         let test1c = columnar::Columnar::as_columns(test1s.iter());
-        for (a, b) in test1s.into_iter().zip((&test1c).into_index_iter()) {
+        for (a, b) in test1s.into_iter().zip(IterOwn::new(0, &test1c)) {
             assert_eq!(a.foo.len(), b.foo.len());
             assert_eq!(a.bar, *b.bar);
         }
@@ -153,7 +153,7 @@ mod test {
 
         println!("{:?}", test3c);
 
-        let iterc = (&test3c).into_index_iter();
+        let iterc = IterOwn::new(0, &test3c);
 
         for (a, b) in test3s.into_iter().zip(iterc) {
             match (a, &b) {

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -129,9 +129,38 @@ mod sizes {
         type Ref = usize;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { self.values.index_as(index).try_into().expect("Usizes values should fit in `usize`") }
     }
+    impl<CV: IndexAs<u64> + Len> crate::Sequence for Usizes<CV>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<CV: IndexAs<u64>> Index for &Usizes<CV> {
         type Ref = usize;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { self.values.index_as(index).try_into().expect("Usizes values should fit in `usize`") }
+    }
+    impl<'a, CV: IndexAs<u64> + Len> crate::Sequence for &'a Usizes<CV> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
     }
     impl<CV: for<'a> Push<&'a u64>> Push<usize> for Usizes<CV> {
         #[inline]
@@ -206,9 +235,38 @@ mod sizes {
         type Ref = isize;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { self.values.index_as(index).try_into().expect("Isizes values should fit in `isize`") }
     }
+    impl<CV: IndexAs<i64> + Len> crate::Sequence for Isizes<CV>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<CV: IndexAs<i64>> Index for &Isizes<CV> {
         type Ref = isize;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { self.values.index_as(index).try_into().expect("Isizes values should fit in `isize`") }
+    }
+    impl<'a, CV: IndexAs<i64> + Len> crate::Sequence for &'a Isizes<CV> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
     }
     impl<CV: for<'a> Push<&'a i64>> Push<isize> for Isizes<CV> {
         #[inline]
@@ -288,9 +346,38 @@ mod chars {
         type Ref = char;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { char::from_u32(self.values.index_as(index)).unwrap() }
     }
+    impl<CV: IndexAs<Encoded> + Len> crate::Sequence for Chars<CV>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<CV: IndexAs<Encoded>> Index for &Chars<CV> {
         type Ref = char;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { char::from_u32(self.values.index_as(index)).unwrap() }
+    }
+    impl<'a, CV: IndexAs<Encoded> + Len> crate::Sequence for &'a Chars<CV> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
     }
     impl<CV: for<'a> Push<&'a Encoded>> Push<char> for Chars<CV> {
         #[inline]
@@ -370,9 +457,38 @@ mod larges {
         type Ref = u128;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { u128::from_le_bytes(self.values.index_as(index)) }
     }
+    impl<CV: IndexAs<Encoded> + Len> crate::Sequence for U128s<CV>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<CV: IndexAs<Encoded>> Index for &U128s<CV> {
         type Ref = u128;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { u128::from_le_bytes(self.values.index_as(index)) }
+    }
+    impl<'a, CV: IndexAs<Encoded> + Len> crate::Sequence for &'a U128s<CV> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
     }
     impl<CV: for<'a> Push<&'a Encoded>> Push<u128> for U128s<CV> {
         #[inline]
@@ -442,9 +558,38 @@ mod larges {
         type Ref = i128;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { i128::from_le_bytes(self.values.index_as(index)) }
     }
+    impl<CV: IndexAs<Encoded> + Len> crate::Sequence for I128s<CV>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<CV: IndexAs<Encoded>> Index for &I128s<CV> {
         type Ref = i128;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref { i128::from_le_bytes(self.values.index_as(index)) }
+    }
+    impl<'a, CV: IndexAs<Encoded> + Len> crate::Sequence for &'a I128s<CV> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
     }
     impl<CV: for<'a> Push<&'a Encoded>> Push<i128> for I128s<CV> {
         #[inline]
@@ -535,10 +680,39 @@ pub mod offsets {
             #[inline(always)]
             fn get(&self, index: usize) -> Self::Ref { (index as u64 + 1) * K }
         }
+        impl<const K: u64, CC: CopyAs<u64>> crate::Sequence for Fixeds<K, CC>
+        where
+            Self: Copy,
+        {
+            type Ref = <Self as crate::Index>::Ref;
+            type Iter = crate::common::IterOwn<Self>;
+            #[inline(always)]
+            fn seq_iter(self) -> Self::Iter {
+                let len = crate::Len::len(&self);
+                crate::common::IterOwn::with_range(self, 0..len)
+            }
+            #[inline(always)]
+            fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+                crate::common::IterOwn::with_range(self, range)
+            }
+        }
         impl<'a, const K: u64, CC> Index for &'a Fixeds<K, CC> {
             type Ref = u64;
             #[inline(always)]
             fn get(&self, index: usize) -> Self::Ref { (index as u64 + 1) * K }
+        }
+        impl<'a, const K: u64, CC: CopyAs<u64>> crate::Sequence for &'a Fixeds<K, CC> {
+            type Ref = <Self as crate::Index>::Ref;
+            type Iter = crate::common::IterOwn<Self>;
+            #[inline(always)]
+            fn seq_iter(self) -> Self::Iter {
+                let len = crate::Len::len(&self);
+                crate::common::IterOwn::with_range(self, 0..len)
+            }
+            #[inline(always)]
+            fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+                crate::common::IterOwn::with_range(self, range)
+            }
         }
 
         impl<'a, const K: u64, T> Push<T> for Fixeds<K> {
@@ -661,6 +835,22 @@ pub mod offsets {
                 let length = self.head.index_as(1);
                 let stride = self.head.index_as(0);
                 if index < length { (index+1) * stride } else { self.bounds.index_as((index - length) as usize) }
+            }
+        }
+        impl<BC: IndexAs<u64> + Len, HC: IndexAs<u64>> crate::Sequence for Strides<BC, HC>
+        where
+            Self: Copy,
+        {
+            type Ref = <Self as crate::Index>::Ref;
+            type Iter = crate::common::IterOwn<Self>;
+            #[inline(always)]
+            fn seq_iter(self) -> Self::Iter {
+                let len = crate::Len::len(&self);
+                crate::common::IterOwn::with_range(self, 0..len)
+            }
+            #[inline(always)]
+            fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+                crate::common::IterOwn::with_range(self, range)
             }
         }
 
@@ -851,10 +1041,39 @@ mod empty {
         #[inline(always)]
         fn get(&self, _index: usize) -> Self::Ref { }
     }
+    impl<CC: CopyAs<u64>> crate::Sequence for Empties<CC>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<'a, CC> Index for &'a Empties<CC> {
         type Ref = &'a ();
         #[inline(always)]
         fn get(&self, _index: usize) -> Self::Ref { &() }
+    }
+    impl<'a, CC: CopyAs<u64>> crate::Sequence for &'a Empties<CC> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
     }
     impl Push<()> for Empties {
         // TODO: check for overflow?
@@ -1033,11 +1252,40 @@ mod boolean {
             (word >> bit) & 1 == 1
         }
     }
+    impl<VC: Len + IndexAs<u64>, TC: IndexAs<u64>> crate::Sequence for Bools<VC, TC>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
 
     impl<VC: Len + IndexAs<u64>, TC: IndexAs<u64>> Index for &Bools<VC, TC> {
         type Ref = bool;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref {
             (*self).get(index)
+        }
+    }
+    impl<'a, VC: Len + IndexAs<u64>, TC: IndexAs<u64>> crate::Sequence for &'a Bools<VC, TC> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
         }
     }
 
@@ -1167,10 +1415,39 @@ mod duration {
             Duration::new(self.seconds.index_as(index), self.nanoseconds.index_as(index))
         }
     }
+    impl<SC: IndexAs<u64> + Len, NC: IndexAs<u32>> crate::Sequence for Durations<SC, NC>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<SC: IndexAs<u64>, NC: IndexAs<u32>> Index for &Durations<SC, NC> {
         type Ref = Duration;
         #[inline(always)] fn get(&self, index: usize) -> Self::Ref {
             Duration::new(self.seconds.index_as(index), self.nanoseconds.index_as(index))
+        }
+    }
+    impl<'a, SC: IndexAs<u64> + Len, NC: IndexAs<u32>> crate::Sequence for &'a Durations<SC, NC> {
+        type Ref = <Self as crate::Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
         }
     }
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,0 +1,66 @@
+//! Sequential iteration over `Borrowed` views.
+//!
+//! `Sequence` is the fast-path companion to [`Index`](crate::Index). It is
+//! implemented on `Copy` borrowed types (`C::Borrowed<'a>`) so the iterator
+//! can be constructed by value and hold inner-`'a` references directly,
+//! avoiding any reference to the borrowed shell itself.
+//!
+//! Trivial impls use [`crate::common::IterOwn`] as the iterator type; types
+//! with faster sequential strategies (e.g. [`crate::Repeats`]) override with
+//! a specialized iterator that maintains incremental state.
+
+use core::ops::Range;
+
+/// A borrowed view that can yield its elements sequentially.
+///
+/// `Sequence` is implemented on `Copy` borrowed types. The iterator is
+/// constructed by consuming `self` by value; its state owns the inner `'a`
+/// references directly, so the lifetime of the returned iterator is tied
+/// to the borrowed data rather than to any outer `&Borrowed` shell.
+pub trait Sequence: Copy {
+    /// Element reference type; fixed by the borrowed type's inner lifetime.
+    type Ref;
+    /// Concrete iterator type that yields `Self::Ref` items.
+    type Iter: Iterator<Item = Self::Ref>;
+    /// Iterates over all elements.
+    fn seq_iter(self) -> Self::Iter;
+    /// Iterates over a sub-range.
+    fn seq_iter_range(self, range: Range<usize>) -> Self::Iter;
+    /// Internal-iteration convenience. Defaults to the external iterator.
+    /// Specialized impls may override with a true stack-only loop.
+    #[inline(always)]
+    fn for_each_in(self, range: Range<usize>, mut f: impl FnMut(Self::Ref)) {
+        for x in self.seq_iter_range(range) {
+            f(x);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Sequence;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn slice_seq_iter_parity() {
+        let data: &[u64] = &[1, 2, 3, 4, 5];
+        let via_seq: Vec<&u64> = data.seq_iter().collect();
+        let via_get: Vec<&u64> = (0..data.len()).map(|i| &data[i]).collect();
+        assert_eq!(via_seq, via_get);
+    }
+
+    #[test]
+    fn slice_seq_iter_range() {
+        let data: &[u64] = &[10, 20, 30, 40, 50];
+        let got: Vec<&u64> = data.seq_iter_range(1..4).collect();
+        assert_eq!(got, vec![&20, &30, &40]);
+    }
+
+    #[test]
+    fn vec_ref_seq_iter_parity() {
+        let v: Vec<u64> = vec![7, 8, 9];
+        let via_seq: Vec<&u64> = (&v).seq_iter().collect();
+        assert_eq!(via_seq, vec![&7u64, &8, &9]);
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -157,6 +157,22 @@ impl<'a, BC: Len+IndexAs<u64>> Index for Strings<BC, &'a [u8]> {
         &self.values[lower .. upper]
     }
 }
+impl<'a, BC: Len+IndexAs<u64>> crate::Sequence for Strings<BC, &'a [u8]>
+where
+    Self: Copy,
+{
+    type Ref = <Self as Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
+    }
+}
 impl<'a, BC: Len+IndexAs<u64>> Index for &'a Strings<BC, Vec<u8>> {
     type Ref = &'a [u8];
     #[inline(always)] fn get(&self, index: usize) -> Self::Ref {
@@ -165,6 +181,19 @@ impl<'a, BC: Len+IndexAs<u64>> Index for &'a Strings<BC, Vec<u8>> {
         let lower: usize = lower.try_into().expect("bounds must fit in `usize`");
         let upper: usize = upper.try_into().expect("bounds must fit in `usize`");
         &self.values[lower .. upper]
+    }
+}
+impl<'a, BC: Len+IndexAs<u64>> crate::Sequence for &'a Strings<BC, Vec<u8>> {
+    type Ref = <Self as Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
     }
 }
 

--- a/src/sums.rs
+++ b/src/sums.rs
@@ -323,6 +323,27 @@ pub mod result {
             }
         }
     }
+    impl<SC, TC, CC, VC, WC> crate::Sequence for Results<SC, TC, CC, VC, WC>
+    where
+        Self: Copy,
+        SC: Index,
+        TC: Index,
+        CC: IndexAs<u64> + Len,
+        VC: IndexAs<u64> + Len,
+        WC: IndexAs<u64>,
+    {
+        type Ref = <Self as Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<'a, SC, TC, CC, VC, WC> Index for &'a Results<SC, TC, CC, VC, WC>
     where
         &'a SC: Index,
@@ -339,6 +360,26 @@ pub mod result {
             } else {
                 Err((&self.errs).get(index - self.indexes.rank(index)))
             }
+        }
+    }
+    impl<'a, SC, TC, CC, VC, WC> crate::Sequence for &'a Results<SC, TC, CC, VC, WC>
+    where
+        &'a SC: Index,
+        &'a TC: Index,
+        CC: IndexAs<u64> + Len,
+        VC: IndexAs<u64> + Len,
+        WC: IndexAs<u64>,
+    {
+        type Ref = <Self as Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
         }
     }
 
@@ -579,6 +620,22 @@ pub mod option {
             }
         }
     }
+    impl<TC: Index, CC: IndexAs<u64> + Len, VC: IndexAs<u64> + Len, WC: IndexAs<u64>> crate::Sequence for Options<TC, CC, VC, WC>
+    where
+        Self: Copy,
+    {
+        type Ref = <Self as Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
+        }
+    }
     impl<'a, TC, CC: IndexAs<u64> + Len, VC: IndexAs<u64> + Len, WC: IndexAs<u64>> Index for &'a Options<TC, CC, VC, WC>
     where &'a TC: Index
     {
@@ -590,6 +647,22 @@ pub mod option {
             } else {
                 None
             }
+        }
+    }
+    impl<'a, TC, CC: IndexAs<u64> + Len, VC: IndexAs<u64> + Len, WC: IndexAs<u64>> crate::Sequence for &'a Options<TC, CC, VC, WC>
+    where
+        &'a TC: Index,
+    {
+        type Ref = <Self as Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
         }
     }
     impl<TC: IndexMut, CC: IndexAs<u64> + Len, VC: IndexAs<u64> + Len> IndexMut for Options<TC, CC, VC> {
@@ -664,15 +737,14 @@ pub mod option {
             // Type annotation is important to avoid some inference overflow.
             let store: Options<Vec<i32>> = Columnar::into_columns((0..100).map(Some));
             assert_eq!(store.len(), 100);
-            assert!((&store).index_iter().zip(0..100).all(|(a, b)| a == Some(&b)));
+            assert!((0..store.len()).map(|i| store.get(i)).zip(0..100).all(|(a, b)| a == Some(b)));
         }
 
         #[test]
         fn round_trip_none() {
             let store = Columnar::into_columns((0..100).map(|_x| None::<i32>));
             assert_eq!(store.len(), 100);
-            let foo = &store;
-            assert!(foo.index_iter().zip(0..100).all(|(a, _b)| a == None));
+            assert!((0..store.len()).map(|i| store.get(i)).zip(0..100).all(|(a, _b)| a == None));
         }
 
         #[test]
@@ -680,7 +752,7 @@ pub mod option {
             // Type annotation is important to avoid some inference overflow.
             let store: Options<Vec<i32>>  = Columnar::into_columns((0..100).map(|x| if x % 2 == 0 { Some(x) } else { None }));
             assert_eq!(store.len(), 100);
-            assert!((&store).index_iter().zip(0..100).all(|(a, b)| a == if b % 2 == 0 { Some(&b) } else { None }));
+            assert!((0..store.len()).map(|i| store.get(i)).zip(0..100).all(|(a, b)| a == if b % 2 == 0 { Some(b) } else { None }));
         }
     }
 }
@@ -797,6 +869,19 @@ pub mod discriminant {
             } else {
                 ((self.offset[0] - 1) as u8, index as u64)
             }
+        }
+    }
+    impl<'a> crate::Sequence for Discriminant<&'a [u8], &'a [u64]> {
+        type Ref = <Self as Index>::Ref;
+        type Iter = crate::common::IterOwn<Self>;
+        #[inline(always)]
+        fn seq_iter(self) -> Self::Iter {
+            let len = crate::Len::len(&self);
+            crate::common::IterOwn::with_range(self, 0..len)
+        }
+        #[inline(always)]
+        fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+            crate::common::IterOwn::with_range(self, range)
         }
     }
 

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -7,7 +7,39 @@ use crate::{Columnar, Container, Borrow, Len, Clear, Index, IndexMut, Push};
 // These are all macro based, because the implementations are very similar.
 // The macro requires two names, one for the store and one for pushable types.
 macro_rules! tuple_impl {
-    ( $($name:ident,$name2:ident,$idx:tt)+) => (
+    ( $seq_iter_name:ident ; $($name:ident,$name2:ident,$idx:tt)+) => (
+
+        /// Composed sequence iterator for tuples: zips field `Sequence::Iter`s.
+        pub struct $seq_iter_name<$($name,)*>($(pub $name,)*);
+
+        impl<$($name: Iterator,)*> Iterator for $seq_iter_name<$($name,)*> {
+            type Item = ($($name::Item,)*);
+            #[inline(always)]
+            fn next(&mut self) -> Option<Self::Item> {
+                Some(($(self.$idx.next()?,)*))
+            }
+            #[inline(always)]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.0.size_hint()
+            }
+        }
+
+        impl<$($name: ExactSizeIterator,)*> ExactSizeIterator for $seq_iter_name<$($name,)*> {}
+
+        impl<$($name: crate::Sequence),*> crate::Sequence for ($($name,)*) {
+            type Ref = ($($name::Ref,)*);
+            type Iter = $seq_iter_name<$($name::Iter,)*>;
+            #[inline(always)]
+            fn seq_iter(self) -> Self::Iter {
+                let ($($name,)*) = self;
+                $seq_iter_name($($name.seq_iter(),)*)
+            }
+            #[inline(always)]
+            fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+                let ($($name,)*) = self;
+                $seq_iter_name($($name.seq_iter_range(range.clone()),)*)
+            }
+        }
 
         impl<$($name: Columnar),*> Columnar for ($($name,)*) {
             #[inline(always)]
@@ -150,16 +182,16 @@ macro_rules! tuple_impl {
     )
 }
 
-tuple_impl!(A,AA,0);
-tuple_impl!(A,AA,0 B,BB,1);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6 H,HH,7);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6 H,HH,7 I,II,8);
-tuple_impl!(A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6 H,HH,7 I,II,8 J,JJ,9);
+tuple_impl!(TupleSeqIter1; A,AA,0);
+tuple_impl!(TupleSeqIter2; A,AA,0 B,BB,1);
+tuple_impl!(TupleSeqIter3; A,AA,0 B,BB,1 C,CC,2);
+tuple_impl!(TupleSeqIter4; A,AA,0 B,BB,1 C,CC,2 D,DD,3);
+tuple_impl!(TupleSeqIter5; A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4);
+tuple_impl!(TupleSeqIter6; A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5);
+tuple_impl!(TupleSeqIter7; A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6);
+tuple_impl!(TupleSeqIter8; A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6 H,HH,7);
+tuple_impl!(TupleSeqIter9; A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6 H,HH,7 I,II,8);
+tuple_impl!(TupleSeqIter10; A,AA,0 B,BB,1 C,CC,2 D,DD,3 E,EE,4 F,FF,5 G,GG,6 H,HH,7 I,II,8 J,JJ,9);
 
 #[cfg(test)]
 mod test {
@@ -182,5 +214,137 @@ mod test {
             assert_eq!((&column).get((2*i+1) as usize), (&i, &(i as u8), &b""[..]));
         }
 
+    }
+
+    #[test]
+    fn tuple_seq_iter_parity() {
+        use alloc::vec::Vec;
+        use crate::common::{Index, Push};
+        use crate::{Borrow, Sequence};
+
+        let mut column: crate::ContainerOf<(u64, u8)> = Default::default();
+        for i in 0..100u64 {
+            column.push((i, i as u8));
+        }
+        let borrowed = column.borrow();
+        let via_seq: Vec<_> = borrowed.seq_iter().collect();
+        let via_get: Vec<_> = (0..100).map(|i| borrowed.get(i)).collect();
+        assert_eq!(via_seq, via_get);
+    }
+
+    #[test]
+    fn tuple_seq_iter_range_parity() {
+        use alloc::vec::Vec;
+        use crate::common::{Index, Push};
+        use crate::{Borrow, Sequence};
+
+        let mut column: crate::ContainerOf<(u64, u8)> = Default::default();
+        for i in 0..100u64 {
+            column.push((i, i as u8));
+        }
+        let borrowed = column.borrow();
+        let via_seq: Vec<_> = borrowed.seq_iter_range(10..20).collect();
+        let via_get: Vec<_> = (10..20).map(|i| borrowed.get(i)).collect();
+        assert_eq!(via_seq, via_get);
+    }
+
+    #[test]
+    fn derived_struct_seq_iter() {
+        use alloc::vec::Vec;
+        use crate::common::{Index, Push};
+        use crate::{Borrow, Columnar, Sequence};
+
+        #[derive(Columnar, Debug, PartialEq)]
+        #[columnar(derive(PartialEq))]
+        struct Row { key: u64, val: u64 }
+
+        let mut column: <Row as Columnar>::Container = Default::default();
+        for i in 0..50u64 {
+            column.push(&Row { key: i, val: i * 10 });
+        }
+        let borrowed = column.borrow();
+        let via_seq: Vec<_> = borrowed.seq_iter().collect();
+        let via_get: Vec<_> = (0..50).map(|i| borrowed.get(i)).collect();
+        assert_eq!(via_seq, via_get);
+    }
+
+    #[test]
+    fn borrow_then_seq_iter_no_temp_issue() {
+        use alloc::vec::Vec;
+        use crate::common::Push;
+        use crate::{Borrow, Sequence};
+
+        fn collect_values(container: &crate::ContainerOf<(u64, u8)>) -> Vec<(u64, u8)> {
+            container.borrow().seq_iter().map(|(k, v)| (*k, *v)).collect()
+        }
+
+        let mut column: crate::ContainerOf<(u64, u8)> = Default::default();
+        for i in 0..10u64 {
+            column.push((i, i as u8));
+        }
+        let got = collect_values(&column);
+        assert_eq!(got.len(), 10);
+        assert_eq!(got[0], (0u64, 0u8));
+        assert_eq!(got[9], (9u64, 9u8));
+    }
+
+    #[test]
+    fn ref_container_seq_iter() {
+        use alloc::vec::Vec;
+        use crate::common::Push;
+        use crate::{Borrow, Sequence};
+
+        let mut column: crate::ContainerOf<(u64, u8)> = Default::default();
+        for i in 0..10u64 {
+            column.push((i, i as u8));
+        }
+        let ref_column = &column;
+        let via_seq: Vec<_> = ref_column.borrow().seq_iter().collect();
+        assert_eq!(via_seq.len(), 10);
+    }
+
+    #[test]
+    fn drain_hrtb_resolves() {
+        use alloc::vec::Vec;
+        use crate::{ContainerBytes, Sequence, Columnar};
+
+        // Minimal stand-in for timely's DrainContainer.
+        trait MockDrain {
+            type Item<'a> where Self: 'a;
+            type Iter<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
+            fn drain<'a>(&'a mut self) -> Self::Iter<'a>;
+        }
+
+        struct MockColumn<C: ContainerBytes>(C);
+
+        // Deviation from spec: the spec wrote
+        //   `for<'a> C::Borrowed<'a>: Sequence<Ref = <C as Borrow>::Ref<'a>>`
+        // but that HRTB binding triggers E0582 ("binding for associated type
+        // `Ref` references lifetime `'a`, which does not appear in the trait
+        // input types"). Dropping the `Ref = ...` binding and projecting
+        // `Item`/`Iter` through `Sequence` directly resolves cleanly and
+        // still proves the HRTB is usable at the implementor boundary.
+        impl<C> MockDrain for MockColumn<C>
+        where
+            C: ContainerBytes,
+            for<'a> C::Borrowed<'a>: Sequence,
+        {
+            type Item<'a> = <C::Borrowed<'a> as Sequence>::Ref where Self: 'a;
+            type Iter<'a> = <C::Borrowed<'a> as Sequence>::Iter where Self: 'a;
+            fn drain<'a>(&'a mut self) -> Self::Iter<'a> {
+                self.0.borrow().seq_iter()
+            }
+        }
+
+        // `<u64 as Columnar>::Container` is `Vec<u64>`; inherent `Vec::push`
+        // shadows `Push<&u64>`, so the spec's `container.push(&i)` fails to
+        // compile. Passing `i` by value routes through inherent push.
+        let mut container: <u64 as Columnar>::Container = Default::default();
+        for i in 0..20u64 {
+            container.push(i);
+        }
+        let mut col = MockColumn(container);
+        let drained: Vec<_> = col.drain().collect();
+        assert_eq!(drained.len(), 20);
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -175,6 +175,22 @@ impl<TC: Copy, BC: Len+IndexAs<u64>> Index for Vecs<TC, BC> {
         Slice::new(lower, upper, self.values)
     }
 }
+impl<TC: Copy, BC: Len+IndexAs<u64>> crate::Sequence for Vecs<TC, BC>
+where
+    Self: Copy,
+{
+    type Ref = <Self as Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
+    }
+}
 impl<'a, TC, BC: Len+IndexAs<u64>> Index for &'a Vecs<TC, BC> {
     type Ref = Slice<&'a TC>;
     #[inline(always)]
@@ -182,6 +198,19 @@ impl<'a, TC, BC: Len+IndexAs<u64>> Index for &'a Vecs<TC, BC> {
         let lower = if index == 0 { 0 } else { self.bounds.index_as(index - 1) };
         let upper = self.bounds.index_as(index);
         Slice::new(lower, upper, &self.values)
+    }
+}
+impl<'a, TC, BC: Len+IndexAs<u64>> crate::Sequence for &'a Vecs<TC, BC> {
+    type Ref = <Self as Index>::Ref;
+    type Iter = crate::common::IterOwn<Self>;
+    #[inline(always)]
+    fn seq_iter(self) -> Self::Iter {
+        let len = crate::Len::len(&self);
+        crate::common::IterOwn::with_range(self, 0..len)
+    }
+    #[inline(always)]
+    fn seq_iter_range(self, range: core::ops::Range<usize>) -> Self::Iter {
+        crate::common::IterOwn::with_range(self, range)
     }
 }
 impl<TC, BC: Len+IndexAs<u64>> IndexMut for Vecs<TC, BC> {


### PR DESCRIPTION
Introduces a `Sequence` trait on the `Borrowed` side of the crate. Iterators are constructed by consuming the `Copy` borrowed view by value; their state owns the inner `'a` references directly, so `container.borrow().seq_iter()` works without the temp-borrow dangling that afflicted earlier cursor-GAT attempts.

This is an alternative to #105 

## What's fast

* `Repeats::Borrowed` and `Lookbacks::Borrowed` skip per-element `rank()` by maintaining an incremental count of set bits and caching the current bitvector word. About **11x** faster than repeated `get()`.
* Tuples and `#[derive(Columnar)]` structs zip field iterators. A `Repeats` field deep inside a derived struct still gets its rank-free path; benchmarked at **~10x** for composites.
* Every other `Borrowed` impls `Sequence` trivially via `IterOwn<Self>` (which falls back to `get`). No specialization gimmicks.

## Why on `Borrowed`, not `Index`

`Borrowed<'a>` is already `Copy`. Anchoring the iterator's lifetime to the Borrowed's inner `'a` — rather than to a `&Borrowed` shell — removes the dangling-temp class of errors that an `Index::Cursor<'a>` GAT produced. `Index` stays a pure random-access trait.

## HRTB shape

The intended downstream bound is `for<'a> C::Borrowed<'a>: Sequence`. Rust can't accept the stronger form `Sequence<Ref = C::Ref<'a>>` because `Sequence::Ref` is non-GAT (E0582 — binding references an unbound lifetime). In practice callers project through `<C::Borrowed<'a> as Sequence>::Ref`, which equals `C::Ref<'a>` for every impl in the crate; local type inference carries the equality.

## Notes

* `#[derive(Columnar)]` emits `Sequence` for struct containers. Enum containers do not yet have a `Sequence` impl; extending `derive_enum` is follow-up work.
* `common::IterOwn::new(index, slice)` preserves its old two-argument signature, with the slow-path behavior unchanged.