### PR TITLE
Implement Hash for Boxed and TreesRef reference types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 /target
 /wip
+/.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Cargo.lock
 /target
 /wip
-/.worktrees

--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -574,6 +574,9 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
 fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::DataEnum, vis: syn::Visibility, attr: Option<proc_macro2::TokenStream>) -> proc_macro::TokenStream {
 
     if data_enum.variants.iter().all(|variant| variant.fields.is_empty()) {
+        if attr.is_some() {
+            panic!("All-unit enums do not support attributes");
+        }
         return derive_tags(name, generics, data_enum, vis);
     }
 

--- a/src/adts/tree.rs
+++ b/src/adts/tree.rs
@@ -63,6 +63,22 @@ impl<V: Copy, B: Copy> Clone for TreesRef<V, B> {
 }
 impl<V: Copy, B: Copy> Copy for TreesRef<V, B> {}
 
+impl<V, B> core::hash::Hash for TreesRef<V, B>
+where
+    V: Index + Copy,
+    B: IndexAs<u64> + Copy,
+    V::Ref: core::hash::Hash,
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.value().hash(state);
+        let kids = self.kids();
+        kids.hash(state);
+        for i in 0..kids {
+            self.child(i).hash(state);
+        }
+    }
+}
+
 impl<V: Index, B: IndexAs<u64>> TreesRef<V, B> {
     /// The value at this node.
     #[inline(always)]

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -16,7 +16,7 @@ impl<T: Columnar> Columnar for Box<T> {
 }
 
 /// A newtype wrapper around `T` that implements `Deref` and `DerefMut`.
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Hash)]
 pub struct Boxed<T>(pub T);
 
 impl<T> core::ops::Deref for Boxed<T> {


### PR DESCRIPTION
Implements `Hash` for the hand-rolled `Boxed` and `TreesRef` reference types so containers that thread through them can be hashed when their inner refs are hashable.

For the derive-macro-generated `*Reference` types, users opt in via the existing `#[columnar(derive(Hash))]` attribute. For unit structs and all-unit enums (where `Ref` is the user's own type), users derive `Hash` directly on the type. Also panics on `#[columnar(...)]` attached to an all-unit enum, mirroring the existing behavior for unit structs.

Verified by temporarily tightening `Borrow::Ref<'a>: Copy + Hash` to surface all gaps; remaining gaps in the derive-macro-generated types are addressed by the opt-in attribute path rather than codegen.