### PR TITLE
Fix serde bench compile error and exercise feature in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,11 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Cargo check
         run: cargo check
+      - name: Cargo check (all features)
+        run: cargo check --workspace --all-targets --all-features
       - name: Cargo test
         run: cargo test --workspace --all-targets
+      - name: Cargo test (all features)
+        run: cargo test --workspace --all-targets --all-features
       - name: Verify no_std support
         run: cargo check -p test-no-std

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 /target
 /wip
+/.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 Cargo.lock
 /target
 /wip
-/.worktrees

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,5 +1,5 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use columnar::{Columnar, BorrowedOf, Borrow, Clear};
+use columnar::{Columnar, BorrowedOf, Borrow, Clear, FromBytes};
 use columnar::bytes::indexed;
 use serde::{Serialize, Deserialize};
 
@@ -71,7 +71,7 @@ fn goser_decode(b: &mut Bencher) {
     b.bytes = 8 * words.len() as u64;
     b.iter(|| {
         type B<'a> = BorrowedOf<'a, Log>;
-        let foo = indexed::decode::<B>(&words);
+        let foo = B::from_bytes(&mut indexed::decode(&words));
         bencher::black_box(foo);
     });
 }


### PR DESCRIPTION
`benches/serde.rs` called `indexed::decode::<B>(&words)`, but `indexed::decode` is non-generic; the bench was not updated when the API changed. Switch to `B::from_bytes(&mut indexed::decode(&words))` to match the current pattern (e.g. `examples/decode_asm.rs`).

CI ran `cargo test --workspace --all-targets` without `--features serde`, so the serde bench was never built. Add `cargo check --all-features` and `cargo test --all-features` steps so the feature surface is exercised on every PR.