### PR TITLE
Pin columnar_derive dependency exactly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["columnar_derive", "test-no-std"]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = { version = "1.13.2", features = ["const_generics"] }
 bytemuck = { version = "1.20", features = ["min_const_generics"] }
-columnar_derive = { path = "columnar_derive", version = "0.13" }
+columnar_derive = { path = "columnar_derive", version = "=0.13.1" }
 
 [dev-dependencies]
 bencher = "0.1.5"


### PR DESCRIPTION
`columnar_derive` generates code referencing internal `columnar` modules (e.g. `::columnar::_derive`), so a given `columnar` version only compiles with the derive released alongside it.
The loose `version = "0.13"` requirement lets cargo select a newer derive patch even when `columnar` is pinned to an older patch, producing compile failures that no lockfile edit can resolve.

This changes the requirement to `=0.13.1` so pinning `columnar` also pins its derive.
Pinning is one-directional on purpose: users depend on `columnar`, never on `columnar_derive` directly, and `columnar_derive` has no dependency on `columnar`, so a single exact pin locks the pair; the reverse would introduce a cargo dependency cycle.

Note: with `=`, each future `columnar` release must bump this in lockstep with the derive version. release-plz updates path-dependency versions on release and preserves the `=` operator, so this should continue to work automatically.

Fixes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)