### PR TITLE
Implement element_sizes for the remaining FromBytes impls

### DIFF
--- a/columnar_derive/src/lib.rs
+++ b/columnar_derive/src/lib.rs
@@ -332,6 +332,7 @@ fn derive_struct(name: &syn::Ident, generics: &syn::Generics, data_struct: syn::
                 fn from_store(store: &::columnar::bytes::indexed::DecodedStore<'columnar>, offset: &mut usize) -> Self {
                     Self { #(#names: ::columnar::FromBytes::from_store(store, offset),)* }
                 }
+                #[inline(always)]
                 fn element_sizes(sizes: &mut ::columnar::_derive::Vec<usize>) -> ::core::result::Result<(), ::columnar::_derive::String> {
                     #(<#container_types>::element_sizes(sizes)?;)*
                     Ok(())
@@ -527,6 +528,7 @@ fn derive_unit_struct(name: &syn::Ident, _generics: &syn::Generics, vis: syn::Vi
                 *offset += 1;
                 Self { count: w.first().unwrap_or(&0) }
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut ::columnar::_derive::Vec<usize>) -> ::core::result::Result<(), ::columnar::_derive::String> {
                 sizes.push(8);
                 Ok(())
@@ -938,6 +940,7 @@ fn derive_enum(name: &syn::Ident, generics: &syn:: Generics, data_enum: syn::Dat
                         indexes: ::columnar::FromBytes::from_store(store, offset),
                     }
                 }
+                #[inline(always)]
                 fn element_sizes(sizes: &mut ::columnar::_derive::Vec<usize>) -> ::core::result::Result<(), ::columnar::_derive::String> {
                     #(<#container_types>::element_sizes(sizes)?;)*
                     <::columnar::Discriminant<CVar, COff>>::element_sizes(sizes)?;
@@ -1284,6 +1287,7 @@ fn derive_tags(name: &syn::Ident, _generics: &syn:: Generics, data_enum: syn::Da
             fn from_store(store: &::columnar::bytes::indexed::DecodedStore<'columnar>, offset: &mut usize) -> Self {
                 Self { variant: ::columnar::FromBytes::from_store(store, offset) }
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut ::columnar::_derive::Vec<usize>) -> ::core::result::Result<(), ::columnar::_derive::String> {
                 CVar::element_sizes(sizes)
             }

--- a/src/adts/tree.rs
+++ b/src/adts/tree.rs
@@ -221,6 +221,7 @@ impl<'a, TC: crate::FromBytes<'a>, BC: crate::FromBytes<'a>> crate::FromBytes<'a
             values: TC::from_store(store, offset),
         }
     }
+    #[inline(always)]
     fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
         BC::element_sizes(sizes)?;
         BC::element_sizes(sizes)?;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,5 +1,6 @@
 //! Implementations of traits for `Arc<T>`
 use alloc::sync::Arc;
+use alloc::{string::String, vec::Vec};
 
 use crate::{Len, Borrow, AsBytes, FromBytes};
 
@@ -21,6 +22,7 @@ impl<'a, T: FromBytes<'a>> FromBytes<'a> for Arc<T> {
     const SLICE_COUNT: usize = T::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Arc::new(T::from_bytes(bytes)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Arc::new(T::from_store(store, offset)) }
+    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { T::element_sizes(sizes) }
 }
 
 #[cfg(test)]
@@ -48,6 +50,13 @@ mod tests {
         let bytes: Vec<_> = x.borrow().as_bytes().map(|(_, b)| b).collect();
         let y: Arc<&[u8]> = FromBytes::from_bytes(&mut bytes.into_iter());
         assert_eq!(*x, *y);
+    }
+
+    #[test]
+    fn test_element_sizes() {
+        let mut sizes = Vec::new();
+        <Arc<&[u32]> as FromBytes>::element_sizes(&mut sizes).unwrap();
+        assert_eq!(sizes, [4]);
     }
 
     #[test]

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -22,7 +22,7 @@ impl<'a, T: FromBytes<'a>> FromBytes<'a> for Arc<T> {
     const SLICE_COUNT: usize = T::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Arc::new(T::from_bytes(bytes)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Arc::new(T::from_store(store, offset)) }
-    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { T::element_sizes(sizes) }
+    #[inline(always)] fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { T::element_sizes(sizes) }
 }
 
 #[cfg(test)]

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -65,7 +65,7 @@ impl<'a, C: FromBytes<'a>> FromBytes<'a> for Boxed<C> {
     const SLICE_COUNT: usize = C::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Self(C::from_bytes(bytes)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Self(C::from_store(store, offset)) }
-    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { C::element_sizes(sizes) }
+    #[inline(always)] fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { C::element_sizes(sizes) }
 }
 impl<C: Index> Index for Boxed<C> {
     type Ref = Boxed<C::Ref>;

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -6,6 +6,7 @@
 //! We need this wrapper to distinguish which [`Push`] implementation to use, otherwise
 //! the implementations would conflict.
 use alloc::boxed::Box;
+use alloc::{string::String, vec::Vec};
 
 use crate::{AsBytes, Borrow, Clear, Columnar, Container, FromBytes, Index, IndexMut, Len, Push, Ref};
 
@@ -64,6 +65,7 @@ impl<'a, C: FromBytes<'a>> FromBytes<'a> for Boxed<C> {
     const SLICE_COUNT: usize = C::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Self(C::from_bytes(bytes)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Self(C::from_store(store, offset)) }
+    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { C::element_sizes(sizes) }
 }
 impl<C: Index> Index for Boxed<C> {
     type Ref = Boxed<C::Ref>;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -285,7 +285,8 @@ pub mod indexed {
     #[cfg(test)]
     mod test {
 
-        use alloc::{vec, vec::Vec, string::String};
+        use alloc::{boxed::Box, vec, vec::Vec, string::String};
+        use core::time::Duration;
         use crate::{Borrow, ContainerOf};
         use crate::common::Push;
         use crate::AsBytes;
@@ -339,6 +340,29 @@ pub mod indexed {
 
             type B<'a> = crate::BorrowedOf<'a, (u64, String, Vec<u32>)>;
             assert!(super::validate::<B>(&store).is_ok());
+        }
+
+        #[test]
+        fn validate_primitive_containers() {
+            /// Encodes a container holding the listed items and validates the store.
+            macro_rules! check {
+                ($type:ty, $($item:expr),* $(,)?) => {{
+                    let mut column: ContainerOf<$type> = Default::default();
+                    $(column.push(&$item);)*
+                    let mut store = Vec::new();
+                    encode(&mut store, &column.borrow());
+                    super::validate::<crate::BorrowedOf<'_, $type>>(&store)
+                        .expect(concat!(stringify!($type), " should validate"));
+                }};
+            }
+
+            check!(u128, 0, u128::MAX);
+            check!(i128, i128::MIN, 0, i128::MAX);
+            check!(usize, 0, usize::MAX);
+            check!(isize, isize::MIN, 0, isize::MAX);
+            check!(char, 'a', '\u{1f600}');
+            check!(Duration, Duration::new(0, 0), Duration::new(17, 42));
+            check!(Box<u64>, Box::new(0), Box::new(u64::MAX));
         }
 
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,7 +708,7 @@ pub mod common {
             if slices.len() < Self::SLICE_COUNT {
                 return Err(format!("expected {} slices but got {}", Self::SLICE_COUNT, slices.len()));
             }
-            let mut sizes = Vec::new();
+            let mut sizes = Vec::with_capacity(Self::SLICE_COUNT);
             Self::element_sizes(&mut sizes)?;
             for (i, elem_size) in sizes.iter().enumerate() {
                 let (words, tail) = &slices[i];

--- a/src/lookback.rs
+++ b/src/lookback.rs
@@ -128,6 +128,7 @@ impl<'a, TC: crate::FromBytes<'a>, CC: crate::FromBytes<'a>, VC: crate::FromByte
     fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
         Self { inner: crate::FromBytes::from_store(store, offset) }
     }
+    #[inline(always)]
     fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
         <Options<TC, CC, VC, &'a [u64]>>::element_sizes(sizes)
     }
@@ -245,6 +246,7 @@ impl<'a, TC: crate::FromBytes<'a>, VC: crate::FromBytes<'a>, CC: crate::FromByte
     fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
         Self { inner: crate::FromBytes::from_store(store, offset) }
     }
+    #[inline(always)]
     fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
         <Results<TC, VC, CC, RC, &'a [u64]>>::element_sizes(sizes)
     }

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -84,6 +84,7 @@ pub use sizes::{Usizes, Isizes};
 /// Columnar stores for `usize` and `isize`, stored as 64 bits.
 mod sizes {
 
+    use alloc::string::String;
     use crate::*;
     use crate::common::{BorrowIndexAs, PushIndexAs};
 
@@ -160,6 +161,9 @@ mod sizes {
         #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
+        }
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            CV::element_sizes(sizes)
         }
     }
 
@@ -238,6 +242,9 @@ mod sizes {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            CV::element_sizes(sizes)
+        }
     }
 }
 
@@ -245,6 +252,7 @@ pub use chars::{Chars};
 /// Columnar store for `char`, stored as a `u32`.
 mod chars {
 
+    use alloc::string::String;
     use crate::*;
     use crate::common::{BorrowIndexAs, PushIndexAs};
 
@@ -320,6 +328,9 @@ mod chars {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            CV::element_sizes(sizes)
+        }
     }
 }
 
@@ -327,6 +338,7 @@ pub use larges::{U128s, I128s};
 /// Columnar stores for `u128` and `i128`, stored as [u8; 16] bits.
 mod larges {
 
+    use alloc::string::String;
     use crate::*;
     use crate::common::{BorrowIndexAs, PushIndexAs};
 
@@ -402,6 +414,9 @@ mod larges {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            CV::element_sizes(sizes)
+        }
     }
 
     #[derive(Copy, Clone, Default)]
@@ -473,6 +488,9 @@ mod larges {
         #[inline(always)]
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
+        }
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            CV::element_sizes(sizes)
         }
     }
 }
@@ -1075,7 +1093,7 @@ pub use duration::Durations;
 /// A columnar store for `core::time::Duration`.
 mod duration {
 
-    use alloc::vec::Vec;
+    use alloc::{vec::Vec, string::String};
     use core::time::Duration;
     use crate::{Container, Len, Index, IndexAs, Push, Clear, Borrow};
 
@@ -1154,6 +1172,10 @@ mod duration {
                 seconds: SC::from_store(store, offset),
                 nanoseconds: NC::from_store(store, offset),
             }
+        }
+        fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
+            SC::element_sizes(sizes)?;
+            NC::element_sizes(sizes)
         }
     }
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -37,6 +37,7 @@ macro_rules! implement_columnable {
                 debug_assert!(trim <= all.len(), "from_store: trim {trim} exceeds slice length {}", all.len());
                 all.get(..all.len().wrapping_sub(trim)).unwrap_or(&[])
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 sizes.push(core::mem::size_of::<$index_type>());
                 Ok(())
@@ -66,6 +67,7 @@ macro_rules! implement_columnable {
                 debug_assert!(trim <= all.len(), "from_store: trim {trim} exceeds slice length {}", all.len());
                 all.get(..all.len().wrapping_sub(trim)).unwrap_or(&[])
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 sizes.push(core::mem::size_of::<$index_type>() * N);
                 Ok(())
@@ -599,6 +601,7 @@ pub mod offsets {
                 debug_assert!(!w.is_empty(), "Fixeds::from_store: empty count slice");
                 Self { count: w.first().unwrap_or(&0) }
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 sizes.push(8);
                 Ok(())
@@ -714,6 +717,7 @@ pub mod offsets {
                 let bounds = BC::from_store(store, offset);
                 Self { head, bounds }
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 sizes.push(8); // head: [stride, length]
                 BC::element_sizes(sizes)
@@ -923,6 +927,7 @@ mod empty {
             debug_assert!(!w.is_empty(), "Empties::from_store: empty count slice");
             Self { count: w.first().unwrap_or(&0), empty: () }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             sizes.push(8);
             Ok(())
@@ -1021,6 +1026,7 @@ mod boolean {
             debug_assert!(tail.len() >= 2, "Bools::from_store: tail slice too short (len {})", tail.len());
             Self { values, tail }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             VC::element_sizes(sizes)?;
             sizes.push(8); // tail: [last_word, last_bits]

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -162,6 +162,7 @@ mod sizes {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             CV::element_sizes(sizes)
         }
@@ -242,6 +243,7 @@ mod sizes {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             CV::element_sizes(sizes)
         }
@@ -328,6 +330,7 @@ mod chars {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             CV::element_sizes(sizes)
         }
@@ -414,6 +417,7 @@ mod larges {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             CV::element_sizes(sizes)
         }
@@ -489,6 +493,7 @@ mod larges {
         fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self {
             Self { values: CV::from_store(store, offset) }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             CV::element_sizes(sizes)
         }
@@ -1173,6 +1178,7 @@ mod duration {
                 nanoseconds: NC::from_store(store, offset),
             }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             SC::element_sizes(sizes)?;
             NC::element_sizes(sizes)

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,5 +1,6 @@
 //! Implementations of traits for `Rc<T>`
 use alloc::rc::Rc;
+use alloc::{string::String, vec::Vec};
 
 use crate::{Len, Borrow, AsBytes, FromBytes};
 
@@ -21,6 +22,7 @@ impl<'a, T: FromBytes<'a>> FromBytes<'a> for Rc<T> {
     const SLICE_COUNT: usize = T::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Rc::new(T::from_bytes(bytes)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Rc::new(T::from_store(store, offset)) }
+    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { T::element_sizes(sizes) }
 }
 
 #[cfg(test)]
@@ -48,6 +50,13 @@ mod tests {
         let bytes: Vec<_> = x.borrow().as_bytes().map(|(_, b)| b).collect();
         let y: Rc<&[u8]> = FromBytes::from_bytes(&mut bytes.into_iter());
         assert_eq!(*x, *y);
+    }
+
+    #[test]
+    fn test_element_sizes() {
+        let mut sizes = Vec::new();
+        <Rc<&[u32]> as FromBytes>::element_sizes(&mut sizes).unwrap();
+        assert_eq!(sizes, [4]);
     }
 
     #[test]

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -22,7 +22,7 @@ impl<'a, T: FromBytes<'a>> FromBytes<'a> for Rc<T> {
     const SLICE_COUNT: usize = T::SLICE_COUNT;
     #[inline(always)] fn from_bytes(bytes: &mut impl Iterator<Item=&'a [u8]>) -> Self { Rc::new(T::from_bytes(bytes)) }
     #[inline(always)] fn from_store(store: &crate::bytes::indexed::DecodedStore<'a>, offset: &mut usize) -> Self { Rc::new(T::from_store(store, offset)) }
-    fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { T::element_sizes(sizes) }
+    #[inline(always)] fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> { T::element_sizes(sizes) }
 }
 
 #[cfg(test)]

--- a/src/string.rs
+++ b/src/string.rs
@@ -124,6 +124,7 @@ impl<'a, BC: crate::FromBytes<'a>, VC: crate::FromBytes<'a>> crate::FromBytes<'a
             values: VC::from_store(store, offset),
         }
     }
+    #[inline(always)]
     fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
         BC::element_sizes(sizes)?;
         VC::element_sizes(sizes)?;

--- a/src/sums.rs
+++ b/src/sums.rs
@@ -84,6 +84,7 @@ pub mod rank_select {
                 values: <crate::primitive::Bools<VC, &'a [u64]>>::from_store(store, offset),
             }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             CC::element_sizes(sizes)?;
             <crate::primitive::Bools<VC, &'a [u64]>>::element_sizes(sizes)?;
@@ -805,6 +806,7 @@ pub mod result {
                 errs: TC::from_store(store, offset),
             }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             <RankSelect<CC, VC, &'a [u64]>>::element_sizes(sizes)?;
             SC::element_sizes(sizes)?;
@@ -1069,6 +1071,7 @@ pub mod option {
                 somes: TC::from_store(store, offset),
             }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             <RankSelect<CC, VC, &'a [u64]>>::element_sizes(sizes)?;
             TC::element_sizes(sizes)?;
@@ -1372,6 +1375,7 @@ pub mod discriminant {
             let offset_field = crate::FromBytes::from_store(store, offset);
             Self { variant, offset: offset_field }
         }
+        #[inline(always)]
         fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
             <&[u8]>::element_sizes(sizes)?;
             <&[u64]>::element_sizes(sizes)?;

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -87,6 +87,7 @@ macro_rules! tuple_impl {
                 $(let $name = $name::from_store(store, offset);)*
                 ($($name,)*)
             }
+            #[inline(always)]
             fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
                 $($name::element_sizes(sizes)?;)*
                 Ok(())

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -147,6 +147,7 @@ impl<'a, TC: crate::FromBytes<'a>, BC: crate::FromBytes<'a>> crate::FromBytes<'a
             values: TC::from_store(store, offset),
         }
     }
+    #[inline(always)]
     fn element_sizes(sizes: &mut Vec<usize>) -> Result<(), String> {
         BC::element_sizes(sizes)?;
         TC::element_sizes(sizes)?;


### PR DESCRIPTION
The `FromBytes::element_sizes` default returns `Err`, which makes `validate` reject any type that does not override it. Nine impls were missing the override, so containers of `i128`, `u128`, `usize`, `isize`, `char`, `Duration`, and `Box<T>` failed validation with "element_sizes not implemented for this type", and the `Arc`, `Rc`, and `Boxed` wrappers propagated the same error for otherwise valid inner containers.

Each impl now delegates to the container it wraps, matching how it already delegates `from_bytes` and `from_store`. `Durations` reports its seconds and nanoseconds columns in that order, mirroring its slice layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)